### PR TITLE
Add CD workflow for Centra Frontend deployment to staging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,57 @@
+name: CD - Centra Frontend (Dev)
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_VERSION: 24
+      DEPLOY_PATH: /var/www/centra/centra-frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Copy Build to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: ${{ secrets.VPS_PORT }}
+          source: 'dist/*'
+          target: '${{ env.DEPLOY_PATH }}'
+          strip_components: 1
+          rm: true
+
+      - name: Refresh Nginx on VPS
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: ${{ secrets.VPS_PORT }}
+          script: |
+            docker exec centra-web nginx -s reload


### PR DESCRIPTION
- Created a new GitHub Actions workflow for continuous deployment to the staging environment.
- Configured steps for checking out the repository, setting up Node.js and pnpm, installing dependencies, building the project, and deploying to a VPS.
- Included commands to refresh Nginx on the VPS after deployment.