### PR TITLE
components SidebarMenu and AppHeader added to admin and store layouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,8 @@
+import { AdminLayout } from "./layouts/AdminLayout/AdminLayout";
+
 function App() {
     return (
-        <div>
-            <div>
-                <h1>CENTRA - Panel de Control</h1>
-            </div>
-        </div>
+        <AdminLayout  children/>
     );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,9 @@ import { AdminLayout } from "./layouts/AdminLayout/AdminLayout";
 
 function App() {
     return (
-        <AdminLayout  children/>
+        <AdminLayout>
+            <h1>Contenido</h1>
+        </AdminLayout>
     );
 }
 

--- a/src/layouts/AdminLayout/AdminLayout.stories.tsx
+++ b/src/layouts/AdminLayout/AdminLayout.stories.tsx
@@ -9,18 +9,6 @@ const meta: Meta<typeof AdminLayout> = {
     },
     tags: ['autodocs'],
     argTypes: {
-        header: {
-            control: false,
-            table: {
-                type: { summary: 'ReactNode' },
-            },
-        },
-        sider: {
-            control: false,
-            table: {
-                type: { summary: 'ReactNode' },
-            },
-        },
         children: {
             control: false,
             table: {
@@ -36,32 +24,10 @@ type Story = StoryObj<typeof meta>;
 
 export const FullLayout: Story = {
     args: {
-        header: <div>Admin Header</div>,
-        sider: <div>Admin Menu</div>,
-        children: <div>Dashboard Content</div>,
+        children: <div>Dashboard Content</div>
     },
 };
 
-export const WithoutHeader: Story = {
-    args: {
-        sider: <div>Admin Menu</div>,
-        children: <div>Content Only</div>,
-    },
-};
-
-export const WithoutSider: Story = {
-    args: {
-        header: <div>Header Only</div>,
-        children: <div>Main Content</div>,
-    },
-};
-
-export const OnlySider: Story = {
-    args: {
-        sider: <div>Admin Menu</div>,
-    },
-};
-
-export const Empty: Story = {
+export const WithoutChildren: Story = {
     args: {},
 };

--- a/src/layouts/AdminLayout/AdminLayout.test.tsx
+++ b/src/layouts/AdminLayout/AdminLayout.test.tsx
@@ -13,26 +13,6 @@ describe('AdminLayout', () => {
         expect(screen.getByText('Main Content')).toBeDefined();
     });
 
-    test('renders header when provided', () => {
-        render(
-            <AdminLayout header={<div>Header Test</div>}>
-                <div>Content</div>
-            </AdminLayout>
-        );
-
-        expect(screen.getByText('Header Test')).toBeDefined();
-    });
-
-    test('renders sider when provided', () => {
-        render(
-            <AdminLayout sider={<div>Sider Test</div>}>
-                <div>Content</div>
-            </AdminLayout>
-        );
-
-        expect(screen.getByText('Sider Test')).toBeDefined();
-    });
-
     test('does not break when header and sider are not provided', () => {
         render(
             <AdminLayout>
@@ -51,26 +31,6 @@ describe('AdminLayout', () => {
         );
 
         expect(container.firstChild).toHaveStyle('min-height: 100vh');
-    });
-
-    test('does not render header if not provided', () => {
-        render(
-            <AdminLayout>
-                <div>Content</div>
-            </AdminLayout>
-        );
-    
-        expect(screen.queryByText('Header Test')).toBeNull();
-    });
-    
-    test('does not render sider if not provided', () => {
-        render(
-            <AdminLayout>
-                <div>Content</div>
-            </AdminLayout>
-        );
-    
-        expect(screen.queryByText('Sider Test')).toBeNull();
     });
     
     test('renders multiple children correctly', () => {

--- a/src/layouts/AdminLayout/AdminLayout.tsx
+++ b/src/layouts/AdminLayout/AdminLayout.tsx
@@ -1,22 +1,49 @@
 import { Layout } from 'antd';
 import { ReactNode } from 'react';
 import { siderStyle, headerStyle, contentStyle } from './AdminLayout.style';
+import { SidebarMenu } from '@/components/Navigation/SidebarMenu';
+import { AppHeader } from '@/components/Navigation/AppHeader';
 
 const { Content, Header, Sider } = Layout;
 
 interface IAdminLayoutProps {
     children: ReactNode;
-    sider?: ReactNode;
-    header?: ReactNode;
+
 }
 
-export const AdminLayout = ({ children, sider, header }: IAdminLayoutProps) => {
+export const AdminLayout = ({ children }: IAdminLayoutProps) => {
+    const items = [
+        {
+            key: '/admin',
+            label: 'Dashboard',
+        },
+        {
+            key: '/admin/stores',
+            label: 'Tiendas',
+        },
+        {
+            key: '/admin/plans',
+            label: 'Planes',
+        },
+        ];
+
+    //TODO: esto se cambiara por el hook useAuthStore
+    const user = {
+        name: 'Admin User',
+        role: 'admin'
+    }
+
+    //isMobile luego se refactorizara para que sea responsive
     return (
         <Layout style={{ minHeight: '100vh' }}>
-            {sider && <Sider style={siderStyle}>{sider}</Sider>}
+            <Sider style={siderStyle}>
+                <SidebarMenu items={items} isMobile={false} selectedKey='/admin' />
+            </Sider>
 
             <Layout>
-                {header && <Header style={headerStyle}>{header}</Header>}
+                <Header style={headerStyle}>
+                    <AppHeader title='Backoffice Admin' user={user} isMobile={false}/>
+                </Header>
                 <Content style={contentStyle}>{children}</Content>
             </Layout>
         </Layout>

--- a/src/layouts/StoreLayout/StoreLayout.stories.tsx
+++ b/src/layouts/StoreLayout/StoreLayout.stories.tsx
@@ -9,18 +9,6 @@ const meta: Meta<typeof StoreLayout> = {
     },
     tags: ['autodocs'],
     argTypes: {
-        header: {
-            control: false,
-            table: {
-                type: { summary: 'ReactNode' },
-            },
-        },
-        sider: {
-            control: false,
-            table: {
-                type: { summary: 'ReactNode' },
-            },
-        },
         children: {
             control: false,
             table: {
@@ -36,24 +24,10 @@ type Story = StoryObj<typeof meta>;
 
 export const FullLayout: Story = {
     args: {
-        header: <div>Store Header</div>,
-        sider: <div>Store Menu</div>,
         children: <div>Store Content</div>,
     },
 };
 
-export const OnlyContent: Story = {
-    args: {
-        children: <div>Products List</div>,
-    },
-};
-
-export const OnlySider: Story = {
-    args: {
-        sider: <div>Only Menu</div>,
-    },
-};
-
-export const Empty: Story = {
+export const WithoutChildren: Story = {
     args: {},
 };

--- a/src/layouts/StoreLayout/StoreLayout.test.tsx
+++ b/src/layouts/StoreLayout/StoreLayout.test.tsx
@@ -13,27 +13,7 @@ describe('StoreLayout', () => {
     expect(screen.getByText('Store Content')).toBeDefined();
     });
 
-    test('renders header when provided', () => {
-    render(
-        <StoreLayout header={<div>Header</div>}>
-            <div>Content</div>
-        </StoreLayout>
-        );
-
-        expect(screen.getByText('Header')).toBeDefined();
-    });
-
-    test('renders sider when provided', () => {
-        render(
-        <StoreLayout sider={<div>Sider</div>}>
-            <div>Content</div>
-        </StoreLayout>
-        );
-
-        expect(screen.getByText('Sider')).toBeDefined();
-    });
-
-    test('works without optional props', () => {
+    test('renders correctly with only children', () => {
         render(
         <StoreLayout>
             <div>Only Content</div>
@@ -51,27 +31,6 @@ describe('StoreLayout', () => {
     );
 
         expect(container.firstChild).toHaveStyle('min-height: 100vh');
-    });
-});
-
-    test('does not render header if not provided', () => {
-        render(
-        <StoreLayout>
-            <div>Content</div>
-        </StoreLayout>
-        );
-
-        expect(screen.queryByText('Header')).toBeNull();
-    });
-  
-    test('does not render sider if not provided', () => {
-        render(
-        <StoreLayout>
-            <div>Content</div>
-        </StoreLayout>
-        );
-
-        expect(screen.queryByText('Sider')).toBeNull();
     });
 
     test('renders multiple children correctly', () => {
@@ -95,3 +54,4 @@ describe('StoreLayout', () => {
 
     expect(container.querySelector('.ant-layout')).toBeInTheDocument();
     });
+});

--- a/src/layouts/StoreLayout/StoreLayout.tsx
+++ b/src/layouts/StoreLayout/StoreLayout.tsx
@@ -1,30 +1,49 @@
 import { Layout } from 'antd';
 import { ReactNode } from 'react';
 import { siderStyle, headerStyle, contentStyle } from './StoreLayout.style';
+import { SidebarMenu } from '@/components/Navigation/SidebarMenu';
+import { AppHeader } from '@/components/Navigation/AppHeader';
 
 const { Header, Sider, Content } = Layout;
 
 interface IStoreLayoutProps {
     children: ReactNode;
-    sider?: ReactNode;
-    header?: ReactNode;
 }
 
-export const StoreLayout = ({ children , sider, header }: IStoreLayoutProps) => {
+export const StoreLayout = ({ children }: IStoreLayoutProps) => {
+    const items = [
+        {
+            key: 'store/stock',
+            label: 'Stock',
+        },
+        {
+            key: 'store/pos',
+            label: 'POS',
+        },
+        {
+            key: 'store/orders',
+            label: 'Pedidos',
+        },
+        ];
+
+    //TODO: esto se cambiara por el hook useAuthStore
+        const user = {
+            name: 'Admin User',
+            role: 'admin'
+        }
+
+    //isMobile luego se refactorizara para que sea responsive
     return (
         <Layout style={{ minHeight: '100vh' }}>
-            { sider && (
                 <Sider style={siderStyle}>
-                    {sider}
+                    <SidebarMenu items={items} isMobile={false} selectedKey='/stock'/>
                 </Sider>
-            )}
 
             <Layout>
-            { header && (
                 <Header style={headerStyle}>
-                    {header}
+                    <AppHeader title='HSBC' user={user} isMobile={false}/>
                 </Header>
-            )}
+
                 <Content style={contentStyle}>{children}</Content>
             </Layout>
         </Layout>


### PR DESCRIPTION
 se aguarda a que se implemente zustand para finalizar las tareas. Lo que se hizo hasta ahora fue agregar los componentes sidebarmenu y appheader con las props correspondientes a los layouts de admin y store, los cuales funcionan correctamente.