### PR TITLE
feat(stores): add dynamic filters with SelectField components

### DIFF
--- a/src/components/SelectField/SelectField.stories.tsx
+++ b/src/components/SelectField/SelectField.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import SelectField from './SelectField';
+
+const meta: Meta<typeof SelectField> = {
+    title: 'Components/SelectField',
+    component: SelectField,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SelectField>;
+
+export const Default: Story = {
+    args: {
+        name: 'status',
+        label: 'Estado',
+        options: [
+            { label: 'Activo', value: true },
+            { label: 'Inactivo', value: false },
+        ],
+        placeholder: 'Seleccionar...',
+    },
+};
+
+export const Required: Story = {
+    args: {
+        name: 'status',
+        label: 'Estado',
+        options: [
+            { label: 'Activo', value: true },
+            { label: 'Inactivo', value: false },
+        ],
+        rules: [{ required: true, message: 'El estado es requerido' }],
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        name: 'status',
+        label: 'Estado',
+        options: [
+            { label: 'Activo', value: true },
+            { label: 'Inactivo', value: false },
+        ],
+        disabled: true,
+        placeholder: 'Seleccionar...',
+    },
+};

--- a/src/components/SelectField/SelectField.test.tsx
+++ b/src/components/SelectField/SelectField.test.tsx
@@ -1,0 +1,114 @@
+import type { ReactElement } from 'react';
+import { render, screen } from '@testing-library/react';
+import { Form } from 'antd';
+import { describe, test, expect, vi } from 'vitest';
+import SelectField from './SelectField';
+
+vi.mock('antd', async () => {
+    const actual = await vi.importActual('antd');
+    return {
+        ...actual,
+        Select: vi.fn(
+            ({
+                options,
+                placeholder,
+                disabled,
+            }: {
+                options?: { label: string; value: string | number | boolean }[];
+                placeholder?: string;
+                disabled?: boolean;
+            }) => (
+                <select data-testid="mock-select" disabled={disabled}>
+                    {options && options.length > 0 ? (
+                        options.map((opt) => (
+                            <option key={String(opt.value)} value={String(opt.value)}>
+                                {opt.label}
+                            </option>
+                        ))
+                    ) : placeholder ? (
+                        <option value="">{placeholder}</option>
+                    ) : null}
+                </select>
+            )
+        ),
+    };
+});
+
+const renderInForm = (ui: ReactElement) => render(<Form>{ui}</Form>);
+
+describe('SelectField', () => {
+    test('renders label and select', () => {
+        renderInForm(<SelectField name="status" label="Estado" options={[]} />);
+
+        expect(screen.getByText('Estado')).toBeDefined();
+        expect(screen.getByTestId('mock-select')).toBeDefined();
+    });
+
+    test('renders placeholder correctly when no options', () => {
+        renderInForm(
+            <SelectField
+                name="status"
+                label="Estado"
+                options={[]}
+                placeholder="Seleccionar..."
+            />
+        );
+
+        expect(screen.getByText('Seleccionar...')).toBeDefined();
+    });
+
+test('renders options correctly', () => {
+        renderInForm(
+            <SelectField
+                name="status"
+                label="Estado"
+                options={[
+                    { label: 'Activo', value: true },
+                    { label: 'Inactivo', value: false },
+                ]}
+            />
+        );
+
+        expect(screen.getByText('Activo')).toBeInTheDocument();
+        expect(screen.getByText('Inactivo')).toBeInTheDocument();
+    });
+
+    test('renders label correctly', () => {
+        renderInForm(
+            <SelectField
+                name="status"
+                label="Estado"
+                options={[{ label: 'Activo', value: true }]}
+            />
+        );
+
+        expect(screen.getByText('Estado')).toBeDefined();
+    });
+
+    test('applies required rule', () => {
+        renderInForm(
+            <SelectField
+                name="status"
+                label="Estado"
+                options={[{ label: 'Activo', value: true }]}
+                rules={[{ required: true, message: 'El estado es requerido' }]}
+            />
+        );
+
+        expect(screen.getByText('Estado')).toBeDefined();
+    });
+
+    test('forwards select props correctly', () => {
+        renderInForm(
+            <SelectField
+                name="status"
+                label="Estado"
+                options={[{ label: 'Activo', value: true }]}
+                disabled
+            />
+        );
+
+        const select = screen.getByTestId('mock-select');
+        expect(select).toBeDisabled();
+    });
+});

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Form, Select } from 'antd';
+import type { Rule } from 'antd/es/form';
+
+export interface SelectFieldProps {
+    name: string;
+    label?: string;
+    rules?: Rule[];
+    options: { label: string; value: string | number | boolean }[];
+    placeholder?: string;
+    allowClear?: boolean;
+    loading?: boolean;
+    disabled?: boolean;
+}
+
+const SelectField: React.FC<SelectFieldProps> = ({
+    name,
+    label,
+    rules,
+    options,
+    ...selectProps
+}) => {
+    return (
+        <Form.Item
+            name={name}
+            label={label}
+            rules={rules}
+            labelCol={{ style: { paddingBottom: 1 } }}
+        >
+            <Select options={options} {...selectProps} />
+        </Form.Item>
+    );
+};
+
+export default SelectField;

--- a/src/components/SelectField/index.ts
+++ b/src/components/SelectField/index.ts
@@ -1,0 +1,1 @@
+export * from './SelectField';

--- a/src/constants/api/endpoints.ts
+++ b/src/constants/api/endpoints.ts
@@ -2,6 +2,7 @@ export const API_ENDPOINTS = {
     ADMIN: {
         STORES: {
             URL: '/v1/admin/stores',
+            FILTER_OPTIONS: '/v1/admin/stores/filter-options',
         },
     },
 } as const;

--- a/src/features/admin/stores/components/StoreList/StoreList.test.tsx
+++ b/src/features/admin/stores/components/StoreList/StoreList.test.tsx
@@ -21,6 +21,8 @@ describe('StoreList', () => {
             error: null,
             pagination: mockPagination,
             refetch: vi.fn(),
+            filterOptions: null,
+            filterOptionsLoading: false,
         });
 
         render(<StoreList />);
@@ -60,6 +62,8 @@ describe('StoreList', () => {
             error: null,
             pagination: { ...mockPagination, total: 2 },
             refetch: vi.fn(),
+            filterOptions: null,
+            filterOptionsLoading: false,
         });
 
         render(<StoreList />);
@@ -78,6 +82,8 @@ describe('StoreList', () => {
             error: null,
             pagination: mockPagination,
             refetch: vi.fn(),
+            filterOptions: null,
+            filterOptionsLoading: false,
         });
 
         render(<StoreList />);

--- a/src/features/admin/stores/components/StoreSearchBar/StoreSearchBar.css
+++ b/src/features/admin/stores/components/StoreSearchBar/StoreSearchBar.css
@@ -1,15 +1,19 @@
 .storeSearchBar {
-    @apply mb-6 flex flex-wrap items-end gap-3;
+    @apply mb-6;
 }
 
-.storeSearchBarName {
-    @apply mb-0 min-w-[220px] flex-1;
+.storeSearchBarRow {
+    @apply flex flex-wrap items-end gap-3;
 }
 
-.storeSearchBarStatus {
+.storeSearchBarRow > * {
     @apply mb-0 min-w-[180px];
 }
 
-.storeSearchBarAction {
-    @apply mb-0;
+.storeSearchBarName {
+    @apply min-w-[220px] flex-1;
+}
+
+.storeSearchBarActions {
+    @apply flex gap-2 items-end;
 }

--- a/src/features/admin/stores/components/StoreSearchBar/StoreSearchBar.test.tsx
+++ b/src/features/admin/stores/components/StoreSearchBar/StoreSearchBar.test.tsx
@@ -13,6 +13,8 @@ const createMockStoresState = (overrides: Partial<UseStoresReturn> = {}): UseSto
     error: null,
     pagination: { current: 1, total: 0, pageSize: 15 },
     refetch: vi.fn(),
+    filterOptions: null,
+    filterOptionsLoading: false,
     ...overrides,
 });
 
@@ -27,14 +29,34 @@ const renderWithProvider = (storesState: UseStoresReturn) => {
 };
 
 describe('StoreSearchBar', () => {
-    test('renders search controls', () => {
+    test('renders all filter controls', () => {
         const storesState = createMockStoresState();
         renderWithProvider(storesState);
 
         expect(screen.getByLabelText('Nombre')).toBeInTheDocument();
-        expect(screen.getAllByText('Estado').length).toBeGreaterThan(0);
+        expect(screen.getByText('Tipo de Negocio')).toBeInTheDocument();
+        expect(screen.getByText('Plan')).toBeInTheDocument();
+        expect(screen.getByText('Estado')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Filtrar' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Limpiar' })).toBeInTheDocument();
+    });
+
+    test('renders filter options from API when available', () => {
+        const storesState = createMockStoresState({
+            filterOptions: {
+                business_types: [{ id: 1, name: 'Ferretería' }],
+                plans: [{ id: 'plan-1', name: 'Plan Básico' }],
+                is_active: [
+                    { value: true, label: 'Activo' },
+                    { value: false, label: 'Inactivo' },
+                ],
+            },
+        });
+        renderWithProvider(storesState);
+
+        expect(screen.getByText('Tipo de Negocio')).toBeInTheDocument();
+        expect(screen.getByText('Plan')).toBeInTheDocument();
+        expect(screen.getByText('Estado')).toBeInTheDocument();
     });
 
     test('does not call refetch when filtering without any filters', async () => {
@@ -49,17 +71,37 @@ describe('StoreSearchBar', () => {
         expect(refetch).not.toHaveBeenCalled();
     });
 
-    test('calls refetch with filters when form is submitted with name filter', async () => {
+    test('calls refetch with all filters when form is submitted', async () => {
         const user = userEvent.setup();
         const refetch = vi.fn();
-        const storesState = createMockStoresState({ refetch });
+        const storesState = createMockStoresState({
+            refetch,
+            filterOptions: {
+                business_types: [{ id: 1, name: 'Ferretería' }],
+                plans: [{ id: 'plan-1', name: 'Plan Básico' }],
+                is_active: [
+                    { value: true, label: 'Activo' },
+                    { value: false, label: 'Inactivo' },
+                ],
+            },
+        });
 
         renderWithProvider(storesState);
 
         await user.type(screen.getByLabelText('Nombre'), 'Sucursal Centro');
+
+        const businessTypeSelect = screen.getByText('Tipo de Negocio').closest('.ant-select')?.querySelector('.ant-select-selector');
+        if (businessTypeSelect) {
+            await user.click(businessTypeSelect);
+        }
+
         await user.click(screen.getByRole('button', { name: 'Filtrar' }));
 
-        expect(refetch).toHaveBeenCalledWith({ name: 'Sucursal Centro', is_active: undefined });
+        expect(refetch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: 'Sucursal Centro',
+            })
+        );
     });
 
     test('calls refetch with empty filters when reset button is clicked', async () => {
@@ -75,13 +117,21 @@ describe('StoreSearchBar', () => {
         expect(refetch).toHaveBeenCalledWith({});
     });
 
-    test('disables buttons when loading is true', () => {
+    test('disables all controls when loading is true', () => {
         const storesState = createMockStoresState({ loading: true });
 
         renderWithProvider(storesState);
 
         expect(screen.getByRole('button', { name: 'Filtrar' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Limpiar' })).toBeDisabled();
+    });
+
+    test('disables controls when filterOptionsLoading is true', () => {
+        const storesState = createMockStoresState({ filterOptionsLoading: true });
+
+        renderWithProvider(storesState);
+
+        expect(screen.getByRole('button', { name: 'Filtrar' })).toBeDisabled();
     });
 
     test('disables limpiar button when no filters are active', () => {

--- a/src/features/admin/stores/components/StoreSearchBar/StoreSearchBar.tsx
+++ b/src/features/admin/stores/components/StoreSearchBar/StoreSearchBar.tsx
@@ -1,20 +1,34 @@
-import { Form, Input, Select } from 'antd';
+import { Form } from 'antd';
 import { Button } from '@/components/Button';
+import InputField from '@/components/InputField/InputField';
+import SelectField from '@/components/SelectField/SelectField';
 import { useStoresContext } from '@/features/admin/stores/hooks/useStoresContext';
 import type { StoresFilters } from '@/features/admin/stores/types/store.types';
 import './StoreSearchBar.css';
 
+interface StoreFiltersForm {
+    name?: string;
+    business_type_id?: number;
+    plan_id?: string;
+    is_active?: boolean;
+}
+
 export const StoreSearchBar = () => {
-    const { loading, refetch } = useStoresContext();
+    const { loading, filterOptions, filterOptionsLoading, refetch } = useStoresContext();
     const [form] = Form.useForm();
 
     const nameValue = Form.useWatch('name', form);
-    const statusValue = Form.useWatch('status', form);
+    const businessTypeValue = Form.useWatch('business_type_id', form);
+    const planValue = Form.useWatch('plan_id', form);
+    const isActiveValue = Form.useWatch('is_active', form);
 
-    const hasActiveFilters = nameValue || statusValue;
+    const hasActiveFilters =
+        nameValue || businessTypeValue || planValue || isActiveValue !== undefined;
 
-    const handleFinish = (values: { name?: string; status?: 'active' | 'inactive' }) => {
-        const hasFilters = values.name || values.status;
+    const isDisabled = loading || filterOptionsLoading;
+
+    const handleFinish = (values: StoreFiltersForm) => {
+        const hasFilters = values.name || values.business_type_id || values.plan_id || values.is_active !== undefined;
 
         if (!hasFilters) {
             return;
@@ -22,12 +36,9 @@ export const StoreSearchBar = () => {
 
         const filters: StoresFilters = {
             name: values.name,
-            is_active:
-                values.status === 'active'
-                    ? true
-                    : values.status === 'inactive'
-                      ? false
-                      : undefined,
+            business_type_id: values.business_type_id,
+            plan_id: values.plan_id,
+            is_active: values.is_active,
         };
         refetch(filters);
     };
@@ -37,6 +48,24 @@ export const StoreSearchBar = () => {
         refetch({});
     };
 
+    const businessTypeOptions =
+        filterOptions?.business_types.map((bt) => ({
+            label: bt.name,
+            value: bt.id,
+        })) ?? [];
+
+    const planOptions =
+        filterOptions?.plans.map((p) => ({
+            label: p.name,
+            value: p.id,
+        })) ?? [];
+
+    const isActiveOptions =
+        filterOptions?.is_active.map((ia) => ({
+            label: ia.label,
+            value: ia.value,
+        })) ?? [];
+
     return (
         <Form
             form={form}
@@ -44,39 +73,62 @@ export const StoreSearchBar = () => {
             className="storeSearchBar"
             onFinish={handleFinish}
         >
-            <Form.Item name="name" label="Nombre" className="storeSearchBarName">
-                <Input placeholder="Buscar por nombre" allowClear />
-            </Form.Item>
-
-            <Form.Item name="status" label="Estado" className="storeSearchBarStatus">
-                <Select
-                    placeholder="Estado"
+            <div className="storeSearchBarRow">
+                <InputField
+                    name="name"
+                    label="Nombre"
+                    placeholder="Buscar por nombre"
                     allowClear
-                    options={[
-                        { label: 'Activo', value: 'active' },
-                        { label: 'Inactivo', value: 'inactive' },
-                    ]}
+                    disabled={isDisabled}
                 />
-            </Form.Item>
 
-            <Form.Item className="storeSearchBarAction">
-                <Button
-                    variant="primary"
-                    label="Filtrar"
-                    htmlType="submit"
-                    action={() => form.submit()}
-                    disabled={loading}
+                <SelectField
+                    name="business_type_id"
+                    label="Tipo de Negocio"
+                    placeholder="Seleccionar"
+                    options={businessTypeOptions}
+                    allowClear
+                    disabled={isDisabled}
+                    loading={filterOptionsLoading}
                 />
-            </Form.Item>
 
-            <Form.Item className="storeSearchBarAction">
-                <Button
-                    variant="default"
-                    label="Limpiar"
-                    action={handleReset}
-                    disabled={loading || !hasActiveFilters}
+                <SelectField
+                    name="plan_id"
+                    label="Plan"
+                    placeholder="Seleccionar"
+                    options={planOptions}
+                    allowClear
+                    disabled={isDisabled}
+                    loading={filterOptionsLoading}
                 />
-            </Form.Item>
+
+                <SelectField
+                    name="is_active"
+                    label="Estado"
+                    placeholder="Seleccionar"
+                    options={isActiveOptions}
+                    allowClear
+                    disabled={isDisabled}
+                    loading={filterOptionsLoading}
+                />
+
+                <div className="storeSearchBarActions">
+                    <Button
+                        variant="primary"
+                        label="Filtrar"
+                        htmlType="submit"
+                        action={() => form.submit()}
+                        disabled={isDisabled}
+                    />
+
+                    <Button
+                        variant="default"
+                        label="Limpiar"
+                        action={handleReset}
+                        disabled={isDisabled || !hasActiveFilters}
+                    />
+                </div>
+            </div>
         </Form>
     );
 };

--- a/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
@@ -12,6 +12,8 @@ const createMockStoresState = (overrides: Partial<UseStoresReturn> = {}): UseSto
     error: null,
     pagination: { current: 1, total: 0, pageSize: 15 },
     refetch: vi.fn(),
+    filterOptions: null,
+    filterOptionsLoading: false,
     ...overrides,
 });
 

--- a/src/features/admin/stores/hooks/useFilterOptions.ts
+++ b/src/features/admin/stores/hooks/useFilterOptions.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect, useCallback } from 'react';
+import { message } from 'antd';
+import { StoresService } from '../services/stores.service';
+import type { FilterOptions } from '../types/store.types';
+
+interface UseFilterOptionsReturn {
+    filterOptions: FilterOptions | null;
+    loading: boolean;
+    error: string | null;
+}
+
+export const useFilterOptions = (): UseFilterOptionsReturn => {
+    const [filterOptions, setFilterOptions] = useState<FilterOptions | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchFilterOptions = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const options = await StoresService.getFilterOptions();
+            setFilterOptions(options);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Error al cargar opciones de filtro';
+            setError(errorMessage);
+            message.error(errorMessage);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchFilterOptions();
+    }, [fetchFilterOptions]);
+
+    return { filterOptions, loading, error };
+};

--- a/src/features/admin/stores/hooks/useStores.ts
+++ b/src/features/admin/stores/hooks/useStores.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { message } from 'antd';
-import type { Store, StoresFilters } from '../types/store.types';
+import type { FilterOptions, Store, StoresFilters } from '../types/store.types';
 import { StoresService } from '../services/stores.service';
 
 export interface StoresPagination {
@@ -15,7 +15,21 @@ export interface UseStoresReturn {
     error: string | null;
     pagination: StoresPagination;
     refetch: (filters?: StoresFilters) => void;
+    filterOptions: FilterOptions | null;
+    filterOptionsLoading: boolean;
 }
+
+const getErrorMessage = (err: unknown, fallback: string): string => {
+    if (err && typeof err === 'object') {
+        if ('message' in err && typeof (err as { message: unknown }).message === 'string') {
+            return (err as { message: string }).message;
+        }
+        if ('data' in err && (err as { data?: { message?: string } }).data?.message) {
+            return (err as { data: { message: string } }).data.message;
+        }
+    }
+    return fallback;
+};
 
 export const useStores = (): UseStoresReturn => {
     const [stores, setStores] = useState<Store[]>([]);
@@ -26,6 +40,22 @@ export const useStores = (): UseStoresReturn => {
         total: 0,
         pageSize: 15,
     });
+    const [filterOptions, setFilterOptions] = useState<FilterOptions | null>(null);
+    const [filterOptionsLoading, setFilterOptionsLoading] = useState<boolean>(true);
+
+    const fetchFilterOptions = useCallback(async () => {
+        setFilterOptionsLoading(true);
+        try {
+            const options = await StoresService.getFilterOptions();
+            setFilterOptions(options);
+        } catch (err) {
+            const errorMessage = getErrorMessage(err, 'Error al cargar opciones de filtro');
+            setError(errorMessage);
+            message.error(errorMessage);
+        } finally {
+            setFilterOptionsLoading(false);
+        }
+    }, []);
 
     const fetchStores = useCallback(async (filters: StoresFilters) => {
         try {
@@ -38,8 +68,8 @@ export const useStores = (): UseStoresReturn => {
                 current: response.current_page,
                 total: response.total,
             }));
-        } catch {
-            const errorMessage = 'Error al cargar las tiendas';
+        } catch (err) {
+            const errorMessage = getErrorMessage(err, 'Error al cargar las tiendas');
             setError(errorMessage);
             message.error(errorMessage);
         } finally {
@@ -56,8 +86,8 @@ export const useStores = (): UseStoresReturn => {
 
     useEffect(() => {
         fetchStores({ page: 1 });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        fetchFilterOptions();
+    }, [fetchStores, fetchFilterOptions]);
 
-    return { stores, loading, error, pagination, refetch };
+    return { stores, loading, error, pagination, refetch, filterOptions, filterOptionsLoading };
 };

--- a/src/features/admin/stores/services/stores.service.test.ts
+++ b/src/features/admin/stores/services/stores.service.test.ts
@@ -137,4 +137,40 @@ describe('StoresService', () => {
             ).rejects.toThrow('No autorizado');
         });
     });
+
+    describe('getFilterOptions', () => {
+        test('returns filter options on success', async () => {
+            const filterOptionsResponse = {
+                status: 'success' as const,
+                message: 'Opciones de filtro obtenidas correctamente.',
+                data: {
+                    business_types: [{ id: 1, name: 'Ferretería' }],
+                    plans: [{ id: 'plan-1', name: 'Plan Básico' }],
+                    is_active: [
+                        { value: true, label: 'Activo' },
+                        { value: false, label: 'Inactivo' },
+                    ],
+                },
+                errors: null,
+            };
+            mockApi.get.mockResolvedValue({ data: filterOptionsResponse });
+
+            const result = await StoresService.getFilterOptions();
+
+            expect(result).toEqual(filterOptionsResponse.data);
+            expect(mockApi.get).toHaveBeenCalledWith('/v1/admin/stores/filter-options');
+        });
+
+        test('throws error on API error status', async () => {
+            mockApi.get.mockResolvedValue({ data: mockErrorResponse });
+
+            await expect(StoresService.getFilterOptions()).rejects.toThrow('No autorizado');
+        });
+
+        test('throws error on network error', async () => {
+            mockApi.get.mockRejectedValue(new Error('Network error'));
+
+            await expect(StoresService.getFilterOptions()).rejects.toThrow('Network error');
+        });
+    });
 });

--- a/src/features/admin/stores/services/stores.service.ts
+++ b/src/features/admin/stores/services/stores.service.ts
@@ -1,7 +1,8 @@
 import api from '@/api/api.config';
 import { API_ENDPOINTS } from '@/constants/api/endpoints';
+import type { ApiError } from '@/interfaces/ApiErrors.interface';
 import type { ApiListResponse } from '@/interfaces/ApiListResponse.interface';
-import type { CreateStoreDto, StoresFilters, Store, StoresListResponse } from '../types/store.types';
+import type { CreateStoreDto, FilterOptions, StoresFilters, Store, StoresListResponse } from '../types/store.types';
 
 export const StoresService = {
     getStores: async (filters: StoresFilters = {}): Promise<StoresListResponse> => {
@@ -11,7 +12,12 @@ export const StoresService = {
         );
 
         if (data.status === 'error') {
-            throw new Error(data.message);
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
         }
 
         return data.data;
@@ -23,7 +29,12 @@ export const StoresService = {
         );
 
         if (data.status === 'error') {
-            throw new Error(data.message);
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
         }
 
         return data.data;
@@ -36,7 +47,29 @@ export const StoresService = {
         );
 
         if (data.status === 'error') {
-            throw new Error(data.message);
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+
+        return data.data;
+    },
+
+    getFilterOptions: async (): Promise<FilterOptions> => {
+        const { data } = await api.get<ApiListResponse<FilterOptions>>(
+            API_ENDPOINTS.ADMIN.STORES.FILTER_OPTIONS
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
         }
 
         return data.data;

--- a/src/features/admin/stores/types/store.types.ts
+++ b/src/features/admin/stores/types/store.types.ts
@@ -43,3 +43,9 @@ export interface StoresFilters {
     page?: number;
     per_page?: number;
 }
+
+export interface FilterOptions {
+    business_types: { id: number; name: string }[];
+    plans: { id: string; name: string }[];
+    is_active: { value: boolean; label: string }[];
+}

--- a/src/pages/admin/stores/StoresPage.test.tsx
+++ b/src/pages/admin/stores/StoresPage.test.tsx
@@ -11,6 +11,8 @@ const createMockStoresState = (overrides: Partial<UseStoresReturn> = {}): UseSto
     error: null,
     pagination: { current: 1, total: 0, pageSize: 15 },
     refetch: vi.fn(),
+    filterOptions: null,
+    filterOptionsLoading: false,
     ...overrides,
 });
 


### PR DESCRIPTION
- Add SelectField component following InputField pattern
- Add filter-options endpoint and getFilterOptions service method
- Update useStores to expose filterOptions and filterOptionsLoading
- Update StoreSearchBar with business_type_id, plan_id, is_active selects
- Fix error handling to show actual backend messages via ApiError
- Add FilterOptions type and update all related tests