### PR TITLE
feat(stores): add detail view drawer with store information

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@ant-design/icons": "^6.1.1",
     "antd": "^6.3.3",
     "axios": "^1.13.6",
+    "lucide-react": "^1.16.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       axios:
         specifier: ^1.13.6
         version: 1.13.6
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.4)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -2088,6 +2091,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4855,6 +4863,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.16.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   lz-string@1.5.0: {}
 

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import { Drawer as AntDrawer } from 'antd';
+
+interface DrawerProps {
+    open: boolean;
+    onClose: () => void;
+    title: React.ReactNode;
+    children: React.ReactNode;
+    width?: number;
+    loading?: boolean;
+    destroyOnClose?: boolean;
+}
+
+const Drawer: React.FC<DrawerProps> = ({
+    open,
+    onClose,
+    title,
+    children,
+    width = 480,
+    loading = false,
+    destroyOnClose = true,
+}) => {
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+        const checkMobile = () => setIsMobile(window.innerWidth < 768);
+        checkMobile();
+        window.addEventListener('resize', checkMobile);
+        return () => window.removeEventListener('resize', checkMobile);
+    }, []);
+
+    return (
+        <AntDrawer
+            open={open}
+            onClose={onClose}
+            title={title}
+            width={isMobile ? '100%' : width}
+            destroyOnClose={destroyOnClose}
+            closable={!loading}
+            maskClosable={!loading}
+            keyboard={!loading}
+        >
+            {children}
+        </AntDrawer>
+    );
+};
+
+export default Drawer;

--- a/src/components/Drawer/index.ts
+++ b/src/components/Drawer/index.ts
@@ -1,0 +1,1 @@
+export { default as Drawer } from './Drawer';

--- a/src/features/admin/stores/components/StoreDetailDrawer/StoreDetailDrawer.tsx
+++ b/src/features/admin/stores/components/StoreDetailDrawer/StoreDetailDrawer.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import { Spin, message } from 'antd';
+import { MapPin, CreditCard, AlertTriangle, Store, User } from 'lucide-react';
+import Drawer from '@/components/Drawer/Drawer';
+import { StoresService } from '../../services/stores.service';
+import { formatDate } from '@/utils/formatDate';
+import type { ApiError } from '@/interfaces/ApiErrors.interface';
+import type { Store as StoreType } from '../../types/store.types';
+
+interface StoreDetailDrawerProps {
+    open: boolean;
+    onClose: () => void;
+    storeId?: string;
+}
+
+interface FieldProps {
+    label: string;
+    value: string | null | undefined;
+}
+
+const Field = ({ label, value }: FieldProps) => (
+    <div className="flex flex-col gap-0.5">
+        <span className="text-xs text-gray-500 leading-none">{label}</span>
+        <span className="text-sm leading-none">{value ?? '—'}</span>
+    </div>
+);
+
+interface SectionProps {
+    icon: React.ReactNode;
+    title: string;
+    children: React.ReactNode;
+    variant?: 'default' | 'danger';
+}
+
+const Section = ({ icon, title, children, variant = 'default' }: SectionProps) => (
+    <div
+        className={`flex flex-col gap-3 rounded-lg border p-4 ${variant === 'danger' ? 'border-red-200 bg-red-50' : 'border-gray-200 bg-white'}`}
+    >
+        <h3
+            className={`flex items-center gap-2 text-sm font-semibold leading-none ${variant === 'danger' ? 'text-red-600' : 'text-gray-700'}`}
+        >
+            {icon}
+            {title}
+        </h3>
+        <div className="flex flex-col gap-4">{children}</div>
+    </div>
+);
+
+export const StoreDetailDrawer: React.FC<StoreDetailDrawerProps> = ({ open, onClose, storeId }) => {
+    const [store, setStore] = useState<StoreType | null>(null);
+
+    useEffect(() => {
+        if (!open || !storeId) {
+            return;
+        }
+
+        let cancelled = false;
+
+        const loadStore = async () => {
+            try {
+                const data = await StoresService.getById(storeId);
+                if (!cancelled) {
+                    setStore(data);
+                }
+            } catch (err: unknown) {
+                if (!cancelled) {
+                    const apiError = err as ApiError;
+                    message.error(apiError.message || 'No se pudo cargar la tienda.');
+                    onClose();
+                }
+            }
+        };
+
+        loadStore();
+
+        return () => {
+            cancelled = true;
+            setStore(null);
+        };
+    }, [open, storeId, onClose]);
+
+    const loading = open && !store && !!storeId;
+
+    return (
+        <Drawer
+            open={open}
+            onClose={onClose}
+            title={
+                <span className="flex items-center gap-2">
+                    <Store size={18} /> Detalle de Tienda
+                </span>
+            }
+            loading={loading}
+            destroyOnClose={false}
+        >
+            {loading ? (
+                <div className="flex justify-center items-center min-h-[200px]">
+                    <Spin size="large" />
+                </div>
+            ) : store ? (
+                <div className="flex flex-col gap-2">
+                    <Section icon={<User size={16} />} title="Información">
+                        <Field label="Nombre" value={store.name} />
+                        <Field label="CUIT" value={store.cuit} />
+                        <Field label="Email" value={store.email} />
+                        <Field label="Teléfono" value={store.phone} />
+                    </Section>
+
+                    <Section icon={<MapPin size={16} />} title="Ubicación">
+                        <Field label="Dirección" value={store.address} />
+                        <Field label="Ciudad" value={store.city} />
+                        <Field label="Estado" value={store.state} />
+                        <Field label="País" value={store.country} />
+                    </Section>
+
+                    <Section icon={<CreditCard size={16} />} title="Suscripción y Estado">
+                        <Field label="Plan" value={store.plan?.name} />
+                        <Field label="Tipo de Negocio" value={store.business_type?.name} />
+                        <Field label="Fecha de Creación" value={formatDate(store.created_at)} />
+                        <div className="flex flex-col gap-0.5">
+                            <span className="text-xs text-gray-500 leading-none">Estado</span>
+                            <span
+                                className={`text-sm font-semibold leading-none ${store.is_active ? 'text-green-600' : 'text-red-500'}`}
+                            >
+                                {store.is_active ? 'Activo' : 'Inactivo'}
+                            </span>
+                        </div>
+                    </Section>
+
+                    {!store.is_active && (
+                        <Section
+                            icon={<AlertTriangle size={16} />}
+                            title="Inactividad"
+                            variant="danger"
+                        >
+                            <Field label="Motivo" value={store.inactive_reason} />
+                            <Field label="Fecha" value={formatDate(store.inactive_at)} />
+                        </Section>
+                    )}
+                </div>
+            ) : null}
+        </Drawer>
+    );
+};

--- a/src/features/admin/stores/components/StoreDetailDrawer/index.ts
+++ b/src/features/admin/stores/components/StoreDetailDrawer/index.ts
@@ -1,0 +1,1 @@
+export { StoreDetailDrawer } from './StoreDetailDrawer';

--- a/src/features/admin/stores/components/StoresTable/StoresTable.stories.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.stories.tsx
@@ -14,17 +14,20 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     args: {
         onEdit: () => {},
+        onView: () => {},
     },
 };
 
 export const Loading: Story = {
     args: {
         onEdit: () => {},
+        onView: () => {},
     },
 };
 
 export const Empty: Story = {
     args: {
         onEdit: () => {},
+        onView: () => {},
     },
 };

--- a/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
@@ -18,11 +18,11 @@ const createMockStoresState = (overrides: Partial<UseStoresReturn> = {}): UseSto
     ...overrides,
 });
 
-const renderWithProvider = (storesState: UseStoresReturn, onEdit: (store: Store) => void) => {
+const renderWithProvider = (storesState: UseStoresReturn, onEdit: (store: Store) => void, onView: (storeId: string) => void) => {
     return render(
         <MemoryRouter>
             <StoresProvider value={storesState}>
-                <StoresTable onEdit={onEdit} />
+                <StoresTable onEdit={onEdit} onView={onView} />
             </StoresProvider>
         </MemoryRouter>
     );
@@ -55,7 +55,7 @@ describe('StoresTable', () => {
             pagination: { current: 1, total: 1, pageSize: 15 },
         });
 
-        renderWithProvider(storesState, vi.fn());
+        renderWithProvider(storesState, vi.fn(), vi.fn());
 
         expect(screen.getByText('Sucursal Centro')).toBeInTheDocument();
         expect(screen.getByText('Ferretería')).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('StoresTable', () => {
 
     test('renders table columns', () => {
         const storesState = createMockStoresState();
-        renderWithProvider(storesState, vi.fn());
+        renderWithProvider(storesState, vi.fn(), vi.fn());
 
         expect(screen.getByRole('columnheader', { name: 'Nombre' })).toBeInTheDocument();
         expect(screen.getByRole('columnheader', { name: 'Tipo de negocio' })).toBeInTheDocument();
@@ -82,14 +82,14 @@ describe('StoresTable', () => {
             pagination: { current: 1, total: 0, pageSize: 15 },
         });
 
-        renderWithProvider(storesState, vi.fn());
+        renderWithProvider(storesState, vi.fn(), vi.fn());
 
         expect(screen.getByText('No hay tiendas para mostrar')).toBeInTheDocument();
     });
 
     test('shows loading state', () => {
         const storesState = createMockStoresState({ loading: true });
-        const { container } = renderWithProvider(storesState, vi.fn());
+        const { container } = renderWithProvider(storesState, vi.fn(), vi.fn());
 
         expect(container.querySelector('.ant-spin')).toBeInTheDocument();
     });

--- a/src/features/admin/stores/components/StoresTable/StoresTable.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.tsx
@@ -8,9 +8,10 @@ import './StoresTable.css';
 
 interface StoresTableProps {
     onEdit: (store: Store) => void;
+    onView: (storeId: string) => void;
 }
 
-export const StoresTable = ({ onEdit }: StoresTableProps) => {
+export const StoresTable = ({ onEdit, onView }: StoresTableProps) => {
     const { stores, loading, pagination, refetch } = useStoresContext();
 
     const columns = [
@@ -61,7 +62,7 @@ export const StoresTable = ({ onEdit }: StoresTableProps) => {
                     <ActionButton
                         icon={<EyeOutlined />}
                         label="Ver"
-                        href={`/admin/tiendas/${record.id}`}
+                        action={() => onView(record.id)}
                     />
                     <ActionButton
                         icon={<EditOutlined />}

--- a/src/pages/admin/stores/StoresPage.test.tsx
+++ b/src/pages/admin/stores/StoresPage.test.tsx
@@ -35,6 +35,7 @@ describe('StoresPage', () => {
                 error={null}
                 onEdit={vi.fn()}
                 onCreate={vi.fn()}
+                onView={vi.fn()}
             />
         );
 
@@ -53,6 +54,7 @@ describe('StoresPage', () => {
                 error={null}
                 onEdit={vi.fn()}
                 onCreate={vi.fn()}
+                onView={vi.fn()}
             />
         );
 
@@ -71,6 +73,7 @@ describe('StoresPage', () => {
                 error="Error al cargar las tiendas"
                 onEdit={vi.fn()}
                 onCreate={vi.fn()}
+                onView={vi.fn()}
             />
         );
 

--- a/src/pages/admin/stores/StoresPage.tsx
+++ b/src/pages/admin/stores/StoresPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { StoresPageView } from './StoresPageView';
 import { StoreModal } from '@/features/admin/stores/components/StoreModal';
+import { StoreDetailDrawer } from '@/features/admin/stores/components/StoreDetailDrawer';
 import { useStores } from '@/features/admin/stores/hooks/useStores';
 import { useAuthStore } from '@/store/useAuthStore.store';
 import { StoresProvider } from '@/features/admin/stores/contexts/StoresProvider';
@@ -22,6 +23,7 @@ export const StoresPage = () => {
 
     const [modalOpen, setModalOpen] = useState(false);
     const [selectedStore, setSelectedStore] = useState<Store | undefined>(undefined);
+    const [viewStoreId, setViewStoreId] = useState<string | undefined>(undefined);
 
     const handleEdit = (store: Store) => {
         setSelectedStore(store);
@@ -44,6 +46,14 @@ export const StoresPage = () => {
         storesState.refetch();
     };
 
+    const handleView = (storeId: string) => {
+        setViewStoreId(storeId);
+    };
+
+    const handleViewClose = () => {
+        setViewStoreId(undefined);
+    };
+
     return (
         <StoresProvider value={storesState}>
             <StoresPageView
@@ -54,6 +64,7 @@ export const StoresPage = () => {
                 error={storesState.error}
                 onEdit={handleEdit}
                 onCreate={handleCreate}
+                onView={handleView}
             />
             <StoreModal
                 open={modalOpen}
@@ -62,6 +73,11 @@ export const StoresPage = () => {
                 store={selectedStore}
                 filterOptions={storesState.filterOptions}
                 filterOptionsLoading={storesState.filterOptionsLoading}
+            />
+            <StoreDetailDrawer
+                open={!!viewStoreId}
+                onClose={handleViewClose}
+                storeId={viewStoreId}
             />
         </StoresProvider>
     );

--- a/src/pages/admin/stores/StoresPageView.tsx
+++ b/src/pages/admin/stores/StoresPageView.tsx
@@ -16,6 +16,7 @@ interface StoresPageViewProps {
     error: string | null;
     onEdit: (store: Store) => void;
     onCreate: () => void;
+    onView: (storeId: string) => void;
 }
 
 export const StoresPageView = ({
@@ -26,6 +27,7 @@ export const StoresPageView = ({
     error,
     onEdit,
     onCreate,
+    onView,
 }: StoresPageViewProps) => {
     return (
         <div className="storesPage">
@@ -62,7 +64,7 @@ export const StoresPageView = ({
                 <Alert className="storesPageAlert" type="error" description={error} showIcon />
             )}
 
-            <StoresTable onEdit={onEdit} />
+            <StoresTable onEdit={onEdit} onView={onView} />
         </div>
     );
 };


### PR DESCRIPTION
- Add reusable Drawer component (mobile-first, 480px desktop)
- Add StoreDetailDrawer with Section/Field pattern and Lucide icons
- Integrate onView handler in StoresTable and StoresPage
- Install lucide-react for icons