### PR TITLE
feat(pages): add NotFoundPage for 404 catch-all routes

### DIFF
--- a/src/pages/not-found/NotFoundPage.stories.tsx
+++ b/src/pages/not-found/NotFoundPage.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router-dom';
+import NotFoundPage from './NotFoundPage';
+
+const meta: Meta<typeof NotFoundPage> = {
+    title: 'Pages/NotFoundPage',
+    component: NotFoundPage,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                story: 'Página mostrada cuando el usuario navega a una ruta inexistente.',
+            },
+        },
+    },
+    decorators: [
+        (Story) => (
+            <MemoryRouter initialEntries={['/ruta-inexistente']}>
+                <Story />
+            </MemoryRouter>
+        ),
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/pages/not-found/NotFoundPage.test.tsx
+++ b/src/pages/not-found/NotFoundPage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, test, vi } from 'vitest';
+import NotFoundPage from './NotFoundPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
+const mockUseAuthStoreAuthenticated = {
+    isAuthenticated: true,
+    user: { id: 1, name: 'Test User', roles: ['SUPER_ADMIN'] as const },
+};
+
+const mockUseAuthStoreUnauthenticated = {
+    isAuthenticated: false,
+    user: null,
+};
+
+vi.mock('@/store/useAuthStore.store', () => ({
+    useAuthStore: vi.fn(),
+}));
+
+import { useAuthStore } from '@/store/useAuthStore.store';
+
+describe('NotFoundPage', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        vi.clearAllMocks();
+    });
+
+    test('renders 404 result for authenticated user', () => {
+        vi.mocked(useAuthStore).mockReturnValue(mockUseAuthStoreAuthenticated);
+
+        render(
+            <MemoryRouter>
+                <NotFoundPage />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText(/página no encontrada/i)).toBeInTheDocument();
+        expect(screen.getByText(/la página que buscas no existe/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /volver atrás/i })).toBeInTheDocument();
+    });
+
+    test('renders back button that calls navigate(-1)', () => {
+        vi.mocked(useAuthStore).mockReturnValue(mockUseAuthStoreAuthenticated);
+
+        render(
+            <MemoryRouter>
+                <NotFoundPage />
+            </MemoryRouter>
+        );
+
+        const backButton = screen.getByRole('button', { name: /volver atrás/i });
+        backButton.click();
+
+        expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    test('does not render 404 content when user is not authenticated', () => {
+        vi.mocked(useAuthStore).mockReturnValue(mockUseAuthStoreUnauthenticated);
+
+        render(
+            <MemoryRouter>
+                <NotFoundPage />
+            </MemoryRouter>
+        );
+
+        expect(screen.queryByText(/página no encontrada/i)).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/not-found/NotFoundPage.tsx
+++ b/src/pages/not-found/NotFoundPage.tsx
@@ -1,0 +1,30 @@
+import { Result, Button } from 'antd';
+import { useNavigate, Navigate } from 'react-router-dom';
+import { useAuthStore } from '@/store/useAuthStore.store';
+import { AuthLayout } from '@/layouts/AuthLayout';
+
+const NotFoundPage = () => {
+    const { isAuthenticated, user } = useAuthStore();
+    const navigate = useNavigate();
+
+    if (!isAuthenticated || !user) {
+        return <Navigate to="/login" replace />;
+    }
+
+    return (
+        <AuthLayout>
+            <Result
+                status="404"
+                title="Página no encontrada"
+                subTitle="La página que buscas no existe o ha sido movida."
+                extra={
+                    <Button type="primary" onClick={() => navigate(-1)}>
+                        Volver atrás
+                    </Button>
+                }
+            />
+        </AuthLayout>
+    );
+};
+
+export default NotFoundPage;

--- a/src/pages/not-found/index.ts
+++ b/src/pages/not-found/index.ts
@@ -1,0 +1,2 @@
+export { default as NotFoundPage } from './NotFoundPage';
+export { default as NotFoundPageView } from './NotFoundPage';

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -6,6 +6,7 @@ import { RootRedirect } from './RootRedirect';
 import LoginPage from '@/pages/auth/LoginPage';
 import { StoresPage } from '@/pages/admin/stores/StoresPage';
 import { PermissionRoute } from './PermissionRoute';
+import { NotFoundPage } from '@/pages/not-found';
 
 export const router = createBrowserRouter([
     // ── Raíz ─────────────────────────────────────────
@@ -58,5 +59,11 @@ export const router = createBrowserRouter([
                 ],
             },
         ],
+    },
+
+    // ── Catch-all 404 ─────────────────────────────────
+    {
+        path: '*',
+        element: <NotFoundPage />,
     },
 ]);


### PR DESCRIPTION
- Add NotFoundPage component using Ant Design Result (status 404)
- Redirect to /login if user is not authenticated
- Button 'Volver atrás' calls navigate(-1) to go back
- Add NotFoundPage.stories.tsx for Storybook
- Add NotFoundPage.test.tsx with mocked auth store and navigate
- Add catch-all route (path: '*') in router.tsx