### PR TITLE
feat(stores): refactor detail view from Drawer to dedicated page with Tabs

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,34 @@
+import { Card as AntCard } from 'antd';
+import type { CardProps as AntCardProps } from 'antd';
+
+interface CardProps {
+    title?: React.ReactNode;
+    children: React.ReactNode;
+    extra?: React.ReactNode;
+    loading?: boolean;
+    className?: string;
+    styles?: AntCardProps['styles'];
+}
+
+const Card: React.FC<CardProps> = ({
+    title,
+    children,
+    extra,
+    loading,
+    className,
+    styles,
+}) => {
+    return (
+        <AntCard
+            title={title}
+            extra={extra}
+            loading={loading}
+            className={className}
+            styles={styles}
+        >
+            {children}
+        </AntCard>
+    );
+};
+
+export default Card;

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { default as Card } from './Card';

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,37 @@
+import { Tabs as AntTabs } from 'antd';
+
+export interface TabsItem {
+    key: string;
+    label: string;
+    children: React.ReactNode;
+    disabled?: boolean;
+}
+
+interface TabsProps {
+    items: TabsItem[];
+    defaultActiveKey?: string;
+    activeKey?: string;
+    onChange?: (key: string) => void;
+    className?: string;
+}
+
+const Tabs: React.FC<TabsProps> = ({
+    items,
+    defaultActiveKey,
+    activeKey,
+    onChange,
+    className,
+}) => {
+    return (
+        <AntTabs
+            items={items}
+            defaultActiveKey={defaultActiveKey}
+            activeKey={activeKey}
+            onChange={onChange}
+            className={className}
+            animated={{ inkBar: true, tabPane: false }}
+        />
+    );
+};
+
+export default Tabs;

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,0 +1,2 @@
+export { default as Tabs } from './Tabs';
+export type { TabsItem } from './Tabs';

--- a/src/features/admin/stores/components/StoreInfoTab/StoreInfoTab.tsx
+++ b/src/features/admin/stores/components/StoreInfoTab/StoreInfoTab.tsx
@@ -1,0 +1,85 @@
+import { MapPin, CreditCard, AlertTriangle, User } from 'lucide-react';
+import { formatDate } from '@/utils/formatDate';
+import type { Store } from '../../types/store.types';
+
+interface StoreInfoTabProps {
+    store: Store;
+}
+
+interface FieldProps {
+    label: string;
+    value: string | null | undefined;
+}
+
+const Field = ({ label, value }: FieldProps) => (
+    <div className="flex flex-col gap-0.5">
+        <span className="text-xs text-gray-500 leading-none">{label}</span>
+        <span className="text-sm leading-none">{value ?? '—'}</span>
+    </div>
+);
+
+interface SectionProps {
+    icon: React.ReactNode;
+    title: string;
+    children: React.ReactNode;
+    variant?: 'default' | 'danger';
+}
+
+const Section = ({ icon, title, children, variant = 'default' }: SectionProps) => (
+    <div
+        className={`flex flex-col gap-3 rounded-lg border p-4 ${variant === 'danger' ? 'border-red-200 bg-red-50' : 'border-gray-200 bg-white'}`}
+    >
+        <h3
+            className={`flex items-center gap-2 text-sm font-semibold leading-none ${variant === 'danger' ? 'text-red-600' : 'text-gray-700'}`}
+        >
+            {icon}
+            {title}
+        </h3>
+        <div className="flex flex-col gap-4">{children}</div>
+    </div>
+);
+
+export const StoreInfoTab: React.FC<StoreInfoTabProps> = ({ store }) => {
+    return (
+        <div className="flex flex-col gap-2">
+            <Section icon={<User size={16} />} title="Información">
+                <Field label="Nombre" value={store.name} />
+                <Field label="CUIT" value={store.cuit} />
+                <Field label="Email" value={store.email} />
+                <Field label="Teléfono" value={store.phone} />
+            </Section>
+
+            <Section icon={<MapPin size={16} />} title="Ubicación">
+                <Field label="Dirección" value={store.address} />
+                <Field label="Ciudad" value={store.city} />
+                <Field label="Estado" value={store.state} />
+                <Field label="País" value={store.country} />
+            </Section>
+
+            <Section icon={<CreditCard size={16} />} title="Suscripción y Estado">
+                <Field label="Plan" value={store.plan?.name} />
+                <Field label="Tipo de Negocio" value={store.business_type?.name} />
+                <Field label="Fecha de Creación" value={formatDate(store.created_at)} />
+                <div className="flex flex-col gap-0.5">
+                    <span className="text-xs text-gray-500 leading-none">Estado</span>
+                    <span
+                        className={`text-sm font-semibold leading-none ${store.is_active ? 'text-green-600' : 'text-red-500'}`}
+                    >
+                        {store.is_active ? 'Activo' : 'Inactivo'}
+                    </span>
+                </div>
+            </Section>
+
+            {!store.is_active && (
+                <Section
+                    icon={<AlertTriangle size={16} />}
+                    title="Inactividad"
+                    variant="danger"
+                >
+                    <Field label="Motivo" value={store.inactive_reason} />
+                    <Field label="Fecha" value={formatDate(store.inactive_at)} />
+                </Section>
+            )}
+        </div>
+    );
+};

--- a/src/features/admin/stores/components/StoreInfoTab/index.ts
+++ b/src/features/admin/stores/components/StoreInfoTab/index.ts
@@ -1,0 +1,1 @@
+export { StoreInfoTab } from './StoreInfoTab';

--- a/src/features/admin/stores/components/StoresTable/StoresTable.stories.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.stories.tsx
@@ -14,20 +14,17 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     args: {
         onEdit: () => {},
-        onView: () => {},
     },
 };
 
 export const Loading: Story = {
     args: {
         onEdit: () => {},
-        onView: () => {},
     },
 };
 
 export const Empty: Story = {
     args: {
         onEdit: () => {},
-        onView: () => {},
     },
 };

--- a/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
@@ -18,11 +18,11 @@ const createMockStoresState = (overrides: Partial<UseStoresReturn> = {}): UseSto
     ...overrides,
 });
 
-const renderWithProvider = (storesState: UseStoresReturn, onEdit: (store: Store) => void, onView: (storeId: string) => void) => {
+const renderWithProvider = (storesState: UseStoresReturn, onEdit: (store: Store) => void) => {
     return render(
         <MemoryRouter>
             <StoresProvider value={storesState}>
-                <StoresTable onEdit={onEdit} onView={onView} />
+                <StoresTable onEdit={onEdit} />
             </StoresProvider>
         </MemoryRouter>
     );
@@ -55,7 +55,7 @@ describe('StoresTable', () => {
             pagination: { current: 1, total: 1, pageSize: 15 },
         });
 
-        renderWithProvider(storesState, vi.fn(), vi.fn());
+        renderWithProvider(storesState, vi.fn());
 
         expect(screen.getByText('Sucursal Centro')).toBeInTheDocument();
         expect(screen.getByText('Ferretería')).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('StoresTable', () => {
 
     test('renders table columns', () => {
         const storesState = createMockStoresState();
-        renderWithProvider(storesState, vi.fn(), vi.fn());
+        renderWithProvider(storesState, vi.fn());
 
         expect(screen.getByRole('columnheader', { name: 'Nombre' })).toBeInTheDocument();
         expect(screen.getByRole('columnheader', { name: 'Tipo de negocio' })).toBeInTheDocument();
@@ -82,14 +82,14 @@ describe('StoresTable', () => {
             pagination: { current: 1, total: 0, pageSize: 15 },
         });
 
-        renderWithProvider(storesState, vi.fn(), vi.fn());
+        renderWithProvider(storesState, vi.fn());
 
         expect(screen.getByText('No hay tiendas para mostrar')).toBeInTheDocument();
     });
 
     test('shows loading state', () => {
         const storesState = createMockStoresState({ loading: true });
-        const { container } = renderWithProvider(storesState, vi.fn(), vi.fn());
+        const { container } = renderWithProvider(storesState, vi.fn());
 
         expect(container.querySelector('.ant-spin')).toBeInTheDocument();
     });

--- a/src/features/admin/stores/components/StoresTable/StoresTable.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.tsx
@@ -1,4 +1,5 @@
 import { EyeOutlined, EditOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
 import Table from '@/components/Table/Table';
 import { ActionButton } from '@/components/ActionButton';
 import { useStoresContext } from '@/features/admin/stores/hooks/useStoresContext';
@@ -8,11 +9,11 @@ import './StoresTable.css';
 
 interface StoresTableProps {
     onEdit: (store: Store) => void;
-    onView: (storeId: string) => void;
 }
 
-export const StoresTable = ({ onEdit, onView }: StoresTableProps) => {
+export const StoresTable = ({ onEdit }: StoresTableProps) => {
     const { stores, loading, pagination, refetch } = useStoresContext();
+    const navigate = useNavigate();
 
     const columns = [
         {
@@ -62,7 +63,7 @@ export const StoresTable = ({ onEdit, onView }: StoresTableProps) => {
                     <ActionButton
                         icon={<EyeOutlined />}
                         label="Ver"
-                        action={() => onView(record.id)}
+                        action={() => navigate(`/admin/tiendas/${record.id}`)}
                     />
                     <ActionButton
                         icon={<EditOutlined />}

--- a/src/features/admin/stores/hooks/useStore.ts
+++ b/src/features/admin/stores/hooks/useStore.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useCallback } from 'react';
+import { message } from 'antd';
+import { StoresService } from '../services/stores.service';
+import type { Store } from '../types/store.types';
+import type { ApiError } from '@/interfaces/ApiErrors.interface';
+
+interface UseStoreReturn {
+    store: Store | null;
+    loading: boolean;
+    error: string | null;
+    refetch: () => void;
+}
+
+export const useStore = (id: string | undefined): UseStoreReturn => {
+    const [store, setStore] = useState<Store | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchStore = useCallback(async () => {
+        if (!id) {
+            setLoading(false);
+            return;
+        }
+
+        setLoading(true);
+        setError(null);
+
+        try {
+            const data = await StoresService.getById(id);
+            setStore(data);
+        } catch (err) {
+            const apiError = err as ApiError;
+            const errorMessage = apiError.message || 'No se pudo cargar la tienda.';
+            setError(errorMessage);
+            message.error(errorMessage);
+        } finally {
+            setLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        fetchStore();
+    }, [fetchStore]);
+
+    return { store, loading, error, refetch: fetchStore };
+};

--- a/src/pages/admin/stores/StoreShowPage/StoreShowPage.css
+++ b/src/pages/admin/stores/StoreShowPage/StoreShowPage.css
@@ -1,0 +1,19 @@
+.storeShowPage {
+    @apply w-full;
+}
+
+.storeShowPageHeader {
+    @apply mb-6;
+}
+
+.storeShowPageBreadcrumb {
+    @apply mb-4;
+}
+
+.storeShowPageHeaderTop {
+    @apply flex items-center gap-4;
+}
+
+.storeShowPageLoading {
+    @apply flex justify-center items-center min-h-[400px];
+}

--- a/src/pages/admin/stores/StoreShowPage/StoreShowPage.tsx
+++ b/src/pages/admin/stores/StoreShowPage/StoreShowPage.tsx
@@ -1,0 +1,68 @@
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { Breadcrumb, Empty, Spin } from 'antd';
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import { Button } from '@/components/Button';
+import { Card } from '@/components/Card';
+import { Tabs } from '@/components/Tabs';
+import { StoreInfoTab } from '@/features/admin/stores/components/StoreInfoTab';
+import { useStore } from '@/features/admin/stores/hooks/useStore';
+import './StoreShowPage.css';
+
+export const StoreShowPage = () => {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const { store, loading, error } = useStore(id);
+
+    if (loading) {
+        return (
+            <div className="storeShowPageLoading">
+                <Spin size="large" />
+            </div>
+        );
+    }
+
+    if (error || !store || !id) {
+        navigate('/admin/tiendas', { replace: true });
+        return null;
+    }
+
+    const tabItems = [
+        {
+            key: 'general',
+            label: 'Información General',
+            children: <StoreInfoTab store={store} />,
+        },
+        {
+            key: 'users',
+            label: 'Usuarios',
+            children: <Empty description="Próximamente" />,
+        },
+    ];
+
+    return (
+        <div className="storeShowPage">
+            <div className="storeShowPageHeader">
+                <Breadcrumb
+                    className="storeShowPageBreadcrumb"
+                    items={[
+                        { title: <Link to="/admin/dashboard">Admin</Link> },
+                        { title: <Link to="/admin/tiendas">Tiendas</Link> },
+                        { title: store.name },
+                    ]}
+                />
+                <div className="storeShowPageHeaderTop">
+                    <Button
+                        variant="default"
+                        label="Volver"
+                        icon={<ArrowLeftOutlined />}
+                        action={() => navigate('/admin/tiendas')}
+                    />
+                </div>
+            </div>
+
+            <Card>
+                <Tabs items={tabItems} defaultActiveKey="general" />
+            </Card>
+        </div>
+    );
+};

--- a/src/pages/admin/stores/StoreShowPage/index.ts
+++ b/src/pages/admin/stores/StoreShowPage/index.ts
@@ -1,0 +1,1 @@
+export { StoreShowPage } from './StoreShowPage';

--- a/src/pages/admin/stores/StoresPage.test.tsx
+++ b/src/pages/admin/stores/StoresPage.test.tsx
@@ -35,7 +35,6 @@ describe('StoresPage', () => {
                 error={null}
                 onEdit={vi.fn()}
                 onCreate={vi.fn()}
-                onView={vi.fn()}
             />
         );
 
@@ -54,7 +53,6 @@ describe('StoresPage', () => {
                 error={null}
                 onEdit={vi.fn()}
                 onCreate={vi.fn()}
-                onView={vi.fn()}
             />
         );
 
@@ -73,7 +71,6 @@ describe('StoresPage', () => {
                 error="Error al cargar las tiendas"
                 onEdit={vi.fn()}
                 onCreate={vi.fn()}
-                onView={vi.fn()}
             />
         );
 

--- a/src/pages/admin/stores/StoresPage.tsx
+++ b/src/pages/admin/stores/StoresPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { StoresPageView } from './StoresPageView';
 import { StoreModal } from '@/features/admin/stores/components/StoreModal';
-import { StoreDetailDrawer } from '@/features/admin/stores/components/StoreDetailDrawer';
 import { useStores } from '@/features/admin/stores/hooks/useStores';
 import { useAuthStore } from '@/store/useAuthStore.store';
 import { StoresProvider } from '@/features/admin/stores/contexts/StoresProvider';
@@ -23,7 +22,6 @@ export const StoresPage = () => {
 
     const [modalOpen, setModalOpen] = useState(false);
     const [selectedStore, setSelectedStore] = useState<Store | undefined>(undefined);
-    const [viewStoreId, setViewStoreId] = useState<string | undefined>(undefined);
 
     const handleEdit = (store: Store) => {
         setSelectedStore(store);
@@ -46,14 +44,6 @@ export const StoresPage = () => {
         storesState.refetch();
     };
 
-    const handleView = (storeId: string) => {
-        setViewStoreId(storeId);
-    };
-
-    const handleViewClose = () => {
-        setViewStoreId(undefined);
-    };
-
     return (
         <StoresProvider value={storesState}>
             <StoresPageView
@@ -64,7 +54,6 @@ export const StoresPage = () => {
                 error={storesState.error}
                 onEdit={handleEdit}
                 onCreate={handleCreate}
-                onView={handleView}
             />
             <StoreModal
                 open={modalOpen}
@@ -73,11 +62,6 @@ export const StoresPage = () => {
                 store={selectedStore}
                 filterOptions={storesState.filterOptions}
                 filterOptionsLoading={storesState.filterOptionsLoading}
-            />
-            <StoreDetailDrawer
-                open={!!viewStoreId}
-                onClose={handleViewClose}
-                storeId={viewStoreId}
             />
         </StoresProvider>
     );

--- a/src/pages/admin/stores/StoresPageView.tsx
+++ b/src/pages/admin/stores/StoresPageView.tsx
@@ -16,7 +16,6 @@ interface StoresPageViewProps {
     error: string | null;
     onEdit: (store: Store) => void;
     onCreate: () => void;
-    onView: (storeId: string) => void;
 }
 
 export const StoresPageView = ({
@@ -27,7 +26,6 @@ export const StoresPageView = ({
     error,
     onEdit,
     onCreate,
-    onView,
 }: StoresPageViewProps) => {
     return (
         <div className="storesPage">
@@ -64,7 +62,7 @@ export const StoresPageView = ({
                 <Alert className="storesPageAlert" type="error" description={error} showIcon />
             )}
 
-            <StoresTable onEdit={onEdit} onView={onView} />
+            <StoresTable onEdit={onEdit} />
         </div>
     );
 };

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -5,6 +5,7 @@ import { AppLayout } from '@/layouts/AppLayout';
 import { RootRedirect } from './RootRedirect';
 import LoginPage from '@/pages/auth/LoginPage';
 import { StoresPage } from '@/pages/admin/stores/StoresPage';
+import { StoreShowPage } from '@/pages/admin/stores/StoreShowPage';
 import { PermissionRoute } from './PermissionRoute';
 import { NotFoundPage } from '@/pages/not-found';
 
@@ -34,7 +35,10 @@ export const router = createBrowserRouter([
 
                     {
                         element: <PermissionRoute permission="stores.view" />,
-                        children: [{ path: 'tiendas', element: <StoresPage /> }],
+                        children: [
+        { path: 'tiendas', element: <StoresPage /> },
+        { path: 'tiendas/:id', element: <StoreShowPage /> },
+    ],
                     },
 
                     {

--- a/src/router/router.utils.test.ts
+++ b/src/router/router.utils.test.ts
@@ -3,14 +3,14 @@ import { getPageNavigation } from './router.utils';
 
 describe('router utils', () => {
     test('returns configured navigation for the stores admin page', () => {
-        expect(getPageNavigation('/admin/stores')).toEqual({
+        expect(getPageNavigation('/admin/tiendas')).toEqual({
             title: 'Gestión de Tiendas',
             breadcrumbs: [{ label: 'Admin', path: '/admin/dashboard' }, { label: 'Tiendas' }],
         });
     });
 
     test('normalizes trailing slashes before resolving navigation', () => {
-        expect(getPageNavigation('/admin/stores/').title).toBe('Gestión de Tiendas');
+        expect(getPageNavigation('/admin/tiendas/').title).toBe('Gestión de Tiendas');
     });
 
     test('builds fallback navigation from the pathname', () => {

--- a/src/router/router.utils.ts
+++ b/src/router/router.utils.ts
@@ -18,9 +18,17 @@ const routeNavigationMap: Record<string, PageNavigation> = {
         title: 'Dashboard',
         breadcrumbs: [{ label: 'Admin' }, { label: 'Dashboard' }],
     },
-    '/admin/stores': {
+    '/admin/tiendas': {
         title: 'Gestión de Tiendas',
         breadcrumbs: [{ label: 'Admin', path: '/admin/dashboard' }, { label: 'Tiendas' }],
+    },
+    '/admin/tiendas/:id': {
+        title: 'Detalle de Tienda',
+        breadcrumbs: [
+            { label: 'Admin', path: '/admin/dashboard' },
+            { label: 'Tiendas', path: '/admin/tiendas' },
+            { label: 'Detalle' },
+        ],
     },
 };
 
@@ -29,6 +37,7 @@ const segmentLabelMap: Record<string, string> = {
     dashboard: 'Dashboard',
     plans: 'Planes',
     stores: 'Tiendas',
+    tiendas: 'Tiendas',
 };
 
 export function getHomePath(roles: UserRole[]): string {


### PR DESCRIPTION
- Add dynamic route /admin/tiendas/:id for store detail page
- Create StoreShowPage with two tabs: Info General and Usuarios
- Add useStore hook for data fetching with loading/error state
- Create StoreInfoTab extracting drawer content (reuses Sections/Fields)
- Add Tabs and Card wrappers in component library (Ant Design)
- Replace StoresTable 'Ver' action with useNavigate() to detail page
- Remove StoreDetailDrawer from StoresPage (kept for future reuse)
- Update router.utils.ts to use /admin/tiendas instead of /admin/stores
- Update tests and stories to remove onView prop