### PR TITLE
fix(stores): make table responsive mobile-first

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -7,6 +7,7 @@ type TableColumn = {
     title: string;
     dataIndex?: string;
     key: string;
+    responsive?: ('xxxl' | 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs')[];
     render?: (text?: unknown, record?: Record<string, unknown>) => React.ReactNode;
 };
 
@@ -17,6 +18,7 @@ interface TableProps {
     loading?: boolean;
     emptyText?: string;
     onChange?: TableChangeHandler;
+    scroll?: { x?: number | string };
 }
 
 const Table: React.FC<TableProps> = ({
@@ -26,6 +28,7 @@ const Table: React.FC<TableProps> = ({
     loading,
     emptyText,
     onChange,
+    scroll,
 }) => {
     return (
         <AntTable
@@ -36,6 +39,7 @@ const Table: React.FC<TableProps> = ({
             loading={loading}
             locale={{ emptyText: emptyText || 'No hay datos' }}
             onChange={onChange}
+            scroll={scroll}
         />
     );
 };

--- a/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.test.tsx
@@ -58,8 +58,6 @@ describe('StoresTable', () => {
         renderWithProvider(storesState, vi.fn());
 
         expect(screen.getByText('Sucursal Centro')).toBeInTheDocument();
-        expect(screen.getByText('Ferretería')).toBeInTheDocument();
-        expect(screen.getByText('Plan Básico')).toBeInTheDocument();
         expect(screen.getByText('Activo')).toBeInTheDocument();
     });
 
@@ -68,11 +66,7 @@ describe('StoresTable', () => {
         renderWithProvider(storesState, vi.fn());
 
         expect(screen.getByRole('columnheader', { name: 'Nombre' })).toBeInTheDocument();
-        expect(screen.getByRole('columnheader', { name: 'Tipo de negocio' })).toBeInTheDocument();
-        expect(screen.getByRole('columnheader', { name: 'Plan' })).toBeInTheDocument();
         expect(screen.getByRole('columnheader', { name: 'Estado' })).toBeInTheDocument();
-        expect(screen.getByRole('columnheader', { name: 'Fecha de creación' })).toBeInTheDocument();
-        expect(screen.getByRole('columnheader', { name: 'Fecha de inactividad' })).toBeInTheDocument();
         expect(screen.getByRole('columnheader', { name: 'Acciones' })).toBeInTheDocument();
     });
 

--- a/src/features/admin/stores/components/StoresTable/StoresTable.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.tsx
@@ -25,12 +25,14 @@ export const StoresTable = ({ onEdit }: StoresTableProps) => {
             title: 'Tipo de negocio',
             dataIndex: 'business_type',
             key: 'business_type',
+            responsive: ['md'],
             render: (_: unknown, record: Store) => record.business_type?.name ?? '—',
         },
         {
             title: 'Plan',
             dataIndex: 'plan',
             key: 'plan',
+            responsive: ['md'],
             render: (_: unknown, record: Store) => record.plan?.name ?? '—',
         },
         {
@@ -47,12 +49,14 @@ export const StoresTable = ({ onEdit }: StoresTableProps) => {
             title: 'Fecha de creación',
             dataIndex: 'created_at',
             key: 'created_at',
+            responsive: ['md'],
             render: (date: string) => formatDate(date),
         },
         {
             title: 'Fecha de inactividad',
             dataIndex: 'inactive_at',
             key: 'inactive_at',
+            responsive: ['md'],
             render: (date: string | null) => formatDate(date),
         },
         {
@@ -90,6 +94,7 @@ export const StoresTable = ({ onEdit }: StoresTableProps) => {
                 refetch({ page: pag.current ?? 1, per_page: pag.pageSize ?? 15 });
             }}
             emptyText="No hay tiendas para mostrar"
+            scroll={{ x: 'max-content' }}
         />
     );
 };

--- a/src/pages/admin/stores/StoresPage.css
+++ b/src/pages/admin/stores/StoresPage.css
@@ -11,7 +11,7 @@
 }
 
 .storesPageHeaderTop {
-    @apply flex items-start justify-between gap-4;
+    @apply flex flex-wrap items-start justify-between gap-4;
 }
 
 .storesPageHeaderText {
@@ -28,4 +28,19 @@
 
 .storesPageAlert {
     @apply mb-4 py-2 text-sm;
+}
+
+@media (max-width: 768px) {
+    .storesPage {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .storesPageHeader {
+        @apply mb-4;
+    }
+
+    .storesPageTitle {
+        @apply text-xl;
+    }
 }


### PR DESCRIPTION
- Add responsive prop to TableColumn type and scroll prop to Table wrapper
- Hide Tipo de negocio, Plan, Fecha de creación, Fecha de inactividad columns on screens < md breakpoint
- Add scroll={{ x: 'max-content' }} as horizontal scroll safety net
- Restore Estado render function (was accidentally removed)
- Update StoresPage CSS: responsive padding for mobile and flex-wrap on header
- Update tests to match new 3-column mobile layout (Nombre, Estado, Acciones)