### PR TITLE
feat(users): add UserModal for create and edit with validation

### DIFF
--- a/src/features/admin/users/components/StoreUserTable/StoreUserTable.tsx
+++ b/src/features/admin/users/components/StoreUserTable/StoreUserTable.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { Popconfirm, Button as AntButton } from 'antd';
-import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined, EditOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
 import { InputSearch } from '@/components/InputSearch';
 import { Tag } from '@/components/Tag';
 import Table from '@/components/Table/Table';
+import { UserModal } from '../UserModal';
 import { useUsers } from '../../hooks/useUsers';
 import type { User } from '@/entities/User';
 import './StoreUserTable.css';
@@ -14,6 +16,29 @@ interface StoreUserTableProps {
 
 const StoreUserTable: React.FC<StoreUserTableProps> = ({ storeId }) => {
     const { users, loading, pagination, refetch, deleteUser } = useUsers(storeId);
+    const [modalOpen, setModalOpen] = useState(false);
+    const [selectedUser, setSelectedUser] = useState<User | undefined>(undefined);
+
+    const handleNewUser = () => {
+        setSelectedUser(undefined);
+        setModalOpen(true);
+    };
+
+    const handleEditUser = (user: User) => {
+        setSelectedUser(user);
+        setModalOpen(true);
+    };
+
+    const handleCloseModal = () => {
+        setModalOpen(false);
+        setSelectedUser(undefined);
+    };
+
+    const handleSuccess = () => {
+        setModalOpen(false);
+        setSelectedUser(undefined);
+        refetch();
+    };
 
     const columns = [
         {
@@ -46,6 +71,12 @@ const StoreUserTable: React.FC<StoreUserTableProps> = ({ storeId }) => {
             key: 'actions',
             render: (_: unknown, record: User) => (
                 <div className="storeUserTableActions">
+                    <Button
+                        variant="text"
+                        size="small"
+                        icon={<EditOutlined />}
+                        action={() => handleEditUser(record)}
+                    />
                     <Popconfirm
                         title="¿Eliminar usuario?"
                         description="Esta acción no se puede deshacer."
@@ -74,7 +105,7 @@ const StoreUserTable: React.FC<StoreUserTableProps> = ({ storeId }) => {
                     variant="primary"
                     label="Nuevo Usuario"
                     icon={<PlusOutlined />}
-                    action={() => console.log('Nuevo usuario')}
+                    action={handleNewUser}
                 />
             </div>
 
@@ -94,6 +125,14 @@ const StoreUserTable: React.FC<StoreUserTableProps> = ({ storeId }) => {
                 }}
                 emptyText="No hay usuarios para mostrar"
                 scroll={{ x: 'max-content' }}
+            />
+
+            <UserModal
+                open={modalOpen}
+                onClose={handleCloseModal}
+                onSuccess={handleSuccess}
+                storeId={storeId}
+                user={selectedUser}
             />
         </div>
     );

--- a/src/features/admin/users/components/UserForm/UserForm.css
+++ b/src/features/admin/users/components/UserForm/UserForm.css
@@ -1,0 +1,13 @@
+.userFormRow {
+    @apply flex flex-col gap-4 mb-4;
+}
+
+@media (min-width: 768px) {
+    .userFormRow {
+        @apply flex-row gap-4;
+    }
+
+    .userFormRow > * {
+        @apply flex-1;
+    }
+}

--- a/src/features/admin/users/components/UserForm/UserForm.tsx
+++ b/src/features/admin/users/components/UserForm/UserForm.tsx
@@ -1,0 +1,125 @@
+import { Form, message } from 'antd';
+import type { FormInstance } from 'antd';
+import InputField from '@/components/InputField/InputField';
+import InputPassword from '@/components/InputPassword/InputPassword';
+import SelectField from '@/components/SelectField/SelectField';
+import { emailRules, requiredStringRules, passwordRules, confirmPasswordRules, roleRules } from '@/utils/validationRules';
+import type { ApiError } from '@/interfaces/ApiErrors.interface';
+import './UserForm.css';
+
+interface UserFormProps {
+    formId?: string;
+    form?: FormInstance;
+    loading: boolean;
+    isEditing: boolean;
+    onSubmit: (values: { name: string; email: string; password: string; password_confirmation: string; role: string; store_id?: string }) => Promise<void>;
+}
+
+interface UserFormValues {
+    name: string;
+    email: string;
+    password?: string;
+    password_confirmation?: string;
+    role: string;
+}
+
+const roleOptions = [
+    { label: 'STORE_ADMIN', value: 'STORE_ADMIN' },
+    { label: 'STORE_USER', value: 'STORE_USER' },
+];
+
+export const UserForm: React.FC<UserFormProps> = ({
+    formId,
+    form: externalForm,
+    loading,
+    isEditing,
+    onSubmit,
+}) => {
+    const [internalForm] = Form.useForm<UserFormValues>();
+    const form = externalForm ?? internalForm;
+
+    const handleFinishFailed = () => {
+        message.error('Por favor, revisá los campos marcados en rojo.');
+    };
+
+    const handleFinish = async (values: UserFormValues) => {
+        try {
+            const payload = {
+                name: values.name,
+                email: values.email,
+                password: values.password!,
+                password_confirmation: values.password_confirmation!,
+                role: values.role,
+            };
+            await onSubmit(payload);
+        } catch (err) {
+            const apiError = err as ApiError;
+            if (apiError.errors) {
+                const fieldErrors = Object.entries(apiError.errors).map(([field, messages]) => ({
+                    name: [field],
+                    errors: messages,
+                }));
+                form.setFields(fieldErrors as Parameters<FormInstance['setFields']>[0]);
+            }
+        }
+    };
+
+    const passwordFieldRules = isEditing ? [] : passwordRules();
+    const confirmFieldRules = isEditing ? [] : confirmPasswordRules();
+
+    return (
+        <Form
+            form={form}
+            id={formId}
+            layout="vertical"
+            onFinish={handleFinish}
+            onFinishFailed={handleFinishFailed}
+            validateTrigger="onBlur"
+        >
+            <div className="userFormRow">
+                <InputField
+                    name="name"
+                    label="Nombre"
+                    placeholder="Ingresá el nombre"
+                    rules={requiredStringRules('El nombre')}
+                    disabled={loading}
+                />
+                <InputField
+                    name="email"
+                    label="Email"
+                    placeholder="ejemplo@email.com"
+                    rules={emailRules()}
+                    disabled={loading}
+                />
+            </div>
+
+            <div className="userFormRow">
+                <InputPassword
+                    name="password"
+                    label="Contraseña"
+                    placeholder="Mínimo 8 caracteres"
+                    rules={passwordFieldRules}
+                    disabled={loading}
+                />
+                <InputPassword
+                    name="password_confirmation"
+                    label="Confirmar Contraseña"
+                    placeholder="Repetí la contraseña"
+                    rules={confirmFieldRules}
+                    disabled={loading}
+                />
+            </div>
+
+            <div className="userFormRow">
+                <SelectField
+                    name="role"
+                    label="Rol"
+                    placeholder="Seleccionar"
+                    options={roleOptions}
+                    rules={roleRules()}
+                    disabled={loading}
+                />
+            </div>
+        </Form>
+    );
+};

--- a/src/features/admin/users/components/UserForm/index.ts
+++ b/src/features/admin/users/components/UserForm/index.ts
@@ -1,0 +1,1 @@
+export { UserForm } from './UserForm';

--- a/src/features/admin/users/components/UserModal/UserModal.css
+++ b/src/features/admin/users/components/UserModal/UserModal.css
@@ -1,0 +1,11 @@
+.userModalFooter {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 16px;
+}
+
+.userModalFooter > * {
+    min-width: 100px;
+}

--- a/src/features/admin/users/components/UserModal/UserModal.tsx
+++ b/src/features/admin/users/components/UserModal/UserModal.tsx
@@ -1,0 +1,115 @@
+import { useEffect } from 'react';
+import { Form } from 'antd';
+import { Button } from '@/components/Button';
+import Modal from '@/components/Modal/Modal';
+import { UserForm } from '../UserForm';
+import { useUserForm } from '../../hooks/useUserForm';
+import type { User } from '@/entities/User';
+import './UserModal.css';
+
+interface UserModalProps {
+    open: boolean;
+    onClose: () => void;
+    onSuccess: () => void;
+    storeId: string;
+    user?: User;
+}
+
+export const UserModal: React.FC<UserModalProps> = ({
+    open,
+    onClose,
+    onSuccess,
+    storeId,
+    user,
+}) => {
+    const [form] = Form.useForm();
+    const { loading, createUser, updateUser } = useUserForm({ onSuccess });
+
+    const isEditing = !!user;
+    const title = isEditing ? 'Editar Usuario' : 'Crear Usuario';
+
+    useEffect(() => {
+        if (open) {
+            if (user) {
+                form.setFieldsValue({
+                    name: user.name,
+                    email: user.email,
+                    role: user.roles[0] ?? undefined,
+                });
+            } else {
+                form.resetFields();
+            }
+        }
+    }, [open, user, form]);
+
+    const handleSubmit = async (values: { name: string; email: string; password: string; password_confirmation: string; role: string; store_id?: string }) => {
+        if (isEditing && user) {
+            const payload = {
+                name: values.name,
+                email: values.email,
+                role: values.role,
+            };
+            await updateUser(user.id, payload);
+        } else {
+            const payload = {
+                name: values.name,
+                email: values.email,
+                password: values.password,
+                password_confirmation: values.password_confirmation,
+                role: values.role,
+                store_id: storeId,
+            };
+            await createUser(payload as Parameters<typeof createUser>[0]);
+        }
+    };
+
+    const handleClose = () => {
+        if (!loading) {
+            onClose();
+        }
+    };
+
+    return (
+        <Modal
+            open={open}
+            onClose={handleClose}
+            title={title}
+            width={560}
+            footer={
+                <div className="userModalFooter">
+                    <Button
+                        variant="default"
+                        label="Cancelar"
+                        action={handleClose}
+                        disabled={loading}
+                    />
+                    <Button
+                        variant="primary"
+                        label={isEditing ? 'Actualizar' : 'Crear'}
+                        loading={loading}
+                        htmlType="button"
+                        action={() => {
+                            const formEl = document.getElementById(
+                                'userForm'
+                            ) as HTMLFormElement | null;
+                            if (formEl) {
+                                formEl.dispatchEvent(
+                                    new Event('submit', { cancelable: true, bubbles: true })
+                                );
+                            }
+                        }}
+                    />
+                </div>
+            }
+            destroyOnClose={false}
+        >
+            <UserForm
+                formId="userForm"
+                form={form}
+                loading={loading}
+                isEditing={isEditing}
+                onSubmit={handleSubmit}
+            />
+        </Modal>
+    );
+};

--- a/src/features/admin/users/components/UserModal/index.ts
+++ b/src/features/admin/users/components/UserModal/index.ts
@@ -1,0 +1,1 @@
+export { UserModal } from './UserModal';

--- a/src/features/admin/users/hooks/useUserForm.ts
+++ b/src/features/admin/users/hooks/useUserForm.ts
@@ -1,0 +1,69 @@
+import { useState, useCallback } from 'react';
+import { message } from 'antd';
+import { UsersService } from '../services/users.service';
+import type { CreateUserDto, UpdateUserDto } from '../types/user.types';
+import type { ApiError } from '@/interfaces/ApiErrors.interface';
+
+interface UseUserFormReturn {
+    loading: boolean;
+    createUser: (data: CreateUserDto) => Promise<void>;
+    updateUser: (id: number, data: UpdateUserDto) => Promise<void>;
+}
+
+interface UseUserFormOptions {
+    onSuccess?: () => void;
+    onError?: (errors: Record<string, string[]>) => void;
+}
+
+export const useUserForm = (options?: UseUserFormOptions): UseUserFormReturn => {
+    const { onSuccess, onError } = options ?? {};
+    const [loading, setLoading] = useState(false);
+
+    const createUser = useCallback(
+        async (data: CreateUserDto) => {
+            setLoading(true);
+            try {
+                await UsersService.create(data);
+                message.success('Usuario creado correctamente.');
+                onSuccess?.();
+            } catch (err) {
+                const apiError = err as ApiError;
+                if (apiError.errors) {
+                    message.error(apiError.message);
+                    onError?.(apiError.errors);
+                    throw err;
+                } else {
+                    message.error(apiError.message || 'Error al crear el usuario.');
+                }
+            } finally {
+                setLoading(false);
+            }
+        },
+        [onSuccess, onError]
+    );
+
+    const updateUser = useCallback(
+        async (id: number, data: UpdateUserDto) => {
+            setLoading(true);
+            try {
+                await UsersService.update(id, data);
+                message.success('Usuario actualizado correctamente.');
+                onSuccess?.();
+            } catch (err) {
+                const apiError = err as ApiError;
+                if (apiError.errors) {
+                    message.error(apiError.message);
+                    onError?.(apiError.errors);
+                    throw err;
+                } else {
+                    message.error(apiError.message || 'Error al actualizar el usuario.');
+                }
+            } finally {
+                setLoading(false);
+            }
+        },
+        [onSuccess, onError]
+    );
+
+    return { loading, createUser, updateUser };
+};

--- a/src/features/admin/users/services/users.service.test.ts
+++ b/src/features/admin/users/services/users.service.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import api from '@/api/api.config';
+import { UsersService } from './users.service';
+
+vi.mock('@/api/api.config');
+
+type MockApi = {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+};
+
+const mockApi = vi.mocked(api) as unknown as MockApi;
+
+const mockUser = {
+    id: 1,
+    name: 'Juan Pérez',
+    email: 'juan@email.com',
+    store_id: '1',
+    roles: ['STORE_ADMIN'] as const,
+    permissions: ['stores.view'],
+    features: ['stores'] as const,
+};
+
+const mockSuccessListResponse = {
+    status: 'success' as const,
+    message: 'Usuarios obtenidos correctamente.',
+    data: {
+        items: [mockUser],
+        total: 1,
+        per_page: 15,
+        current_page: 1,
+        last_page: 1,
+    },
+    errors: null,
+};
+
+const mockErrorResponse = {
+    status: 'error' as const,
+    message: 'No autorizado',
+    data: null,
+    errors: null,
+};
+
+describe('UsersService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('getUsers', () => {
+        test('returns users list on success', async () => {
+            mockApi.get.mockResolvedValueOnce({ data: mockSuccessListResponse } as never);
+
+            const result = await UsersService.getUsers({ store_id: '1' });
+
+            expect(mockApi.get).toHaveBeenCalledWith('/v1/admin/users', {
+                params: { store_id: '1' },
+            });
+            expect(result.items).toHaveLength(1);
+            expect(result.items[0].name).toBe('Juan Pérez');
+            expect(result.total).toBe(1);
+        });
+
+        test('throws ApiError on error response', async () => {
+            mockApi.get.mockResolvedValueOnce({ data: mockErrorResponse } as never);
+
+            await expect(UsersService.getUsers({})).rejects.toMatchObject({
+                status: 0,
+                message: 'No autorizado',
+            });
+        });
+
+        test('throws on network error', async () => {
+            mockApi.get.mockRejectedValueOnce(new Error('Network error') as never);
+
+            await expect(UsersService.getUsers({})).rejects.toThrow('Network error');
+        });
+    });
+
+    describe('create', () => {
+        test('creates user on success', async () => {
+            const createResponse = {
+                status: 'success' as const,
+                message: 'Usuario creado correctamente.',
+                data: mockUser,
+                errors: null,
+            };
+            mockApi.post.mockResolvedValueOnce({ data: createResponse } as never);
+
+            const payload = {
+                name: 'Juan Pérez',
+                email: 'juan@email.com',
+                password: 'password123',
+                password_confirmation: 'password123',
+                role: 'STORE_ADMIN',
+                store_id: '1',
+            };
+
+            const result = await UsersService.create(payload);
+
+            expect(mockApi.post).toHaveBeenCalledWith('/v1/admin/users', payload);
+            expect(result.name).toBe('Juan Pérez');
+        });
+
+        test('throws ApiError on validation error', async () => {
+            const errorResponse = {
+                status: 'error' as const,
+                message: 'Error de validación',
+                data: null,
+                errors: { email: ['El email ya está en uso.'] },
+            };
+            mockApi.post.mockResolvedValueOnce({ data: errorResponse } as never);
+
+            await expect(UsersService.create({
+                name: 'Juan',
+                email: 'juan@email.com',
+                password: 'password123',
+                password_confirmation: 'password123',
+                role: 'STORE_ADMIN',
+                store_id: '1',
+            })).rejects.toMatchObject({
+                message: 'Error de validación',
+                errors: { email: ['El email ya está en uso.'] },
+            });
+        });
+    });
+
+    describe('update', () => {
+        test('updates user on success', async () => {
+            const updateResponse = {
+                status: 'success' as const,
+                message: 'Usuario actualizado correctamente.',
+                data: { ...mockUser, name: 'Juan Actualizado' },
+                errors: null,
+            };
+            mockApi.put.mockResolvedValueOnce({ data: updateResponse } as never);
+
+            const result = await UsersService.update(1, { name: 'Juan Actualizado' });
+
+            expect(mockApi.put).toHaveBeenCalledWith('/v1/admin/users/1', { name: 'Juan Actualizado' });
+            expect(result.name).toBe('Juan Actualizado');
+        });
+
+        test('throws ApiError on error response', async () => {
+            mockApi.put.mockResolvedValueOnce({ data: mockErrorResponse } as never);
+
+            await expect(UsersService.update(1, { name: 'Test' })).rejects.toMatchObject({
+                status: 0,
+                message: 'No autorizado',
+            });
+        });
+    });
+
+    describe('delete', () => {
+        test('deletes user on success', async () => {
+            const deleteResponse = {
+                status: 'success' as const,
+                message: 'Usuario eliminado.',
+                data: null,
+                errors: null,
+            };
+            mockApi.delete.mockResolvedValueOnce({ data: deleteResponse } as never);
+
+            await expect(UsersService.delete(1)).resolves.toBeUndefined();
+            expect(mockApi.delete).toHaveBeenCalledWith('/v1/admin/users/1');
+        });
+
+        test('throws ApiError on error response', async () => {
+            mockApi.delete.mockResolvedValueOnce({ data: mockErrorResponse } as never);
+
+            await expect(UsersService.delete(1)).rejects.toMatchObject({
+                status: 0,
+                message: 'No autorizado',
+            });
+        });
+    });
+});

--- a/src/features/admin/users/services/users.service.ts
+++ b/src/features/admin/users/services/users.service.ts
@@ -2,7 +2,8 @@ import api from '@/api/api.config';
 import { API_ENDPOINTS } from '@/constants/api/endpoints';
 import type { ApiError } from '@/interfaces/ApiErrors.interface';
 import type { ApiListResponse } from '@/interfaces/ApiListResponse.interface';
-import type { UsersFilters, UsersListResponse } from '../types/user.types';
+import type { UsersFilters, UsersListResponse, CreateUserDto, UpdateUserDto } from '../types/user.types';
+import type { User } from '@/entities/User';
 
 export const UsersService = {
     getUsers: async (filters: UsersFilters = {}): Promise<UsersListResponse> => {
@@ -36,5 +37,41 @@ export const UsersService = {
             };
             throw error;
         }
+    },
+
+    create: async (userData: CreateUserDto): Promise<User> => {
+        const { data } = await api.post<ApiListResponse<User>>(
+            API_ENDPOINTS.ADMIN.USERS.URL,
+            userData
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+
+        return data.data;
+    },
+
+    update: async (id: number, userData: UpdateUserDto): Promise<User> => {
+        const { data } = await api.put<ApiListResponse<User>>(
+            `${API_ENDPOINTS.ADMIN.USERS.URL}/${id}`,
+            userData
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+
+        return data.data;
     },
 };

--- a/src/features/admin/users/types/user.types.ts
+++ b/src/features/admin/users/types/user.types.ts
@@ -14,3 +14,14 @@ export interface UsersFilters {
     page?: number;
     per_page?: number;
 }
+
+export interface CreateUserDto {
+    name: string;
+    email: string;
+    password: string;
+    password_confirmation: string;
+    role: string;
+    store_id: string;
+}
+
+export type UpdateUserDto = Partial<Omit<CreateUserDto, 'store_id'>>;

--- a/src/utils/validationRules.ts
+++ b/src/utils/validationRules.ts
@@ -10,6 +10,18 @@ export const passwordRules = (min = 8): Rule[] => [
     { min, message: `Mínimo ${min} caracteres.` },
 ];
 
+export const confirmPasswordRules = (): Rule[] => [
+    { required: true, message: 'La confirmación de contraseña es obligatoria.' },
+    ({ getFieldValue }) => ({
+        validator: (_, value) => {
+            if (!value || getFieldValue('password') === value) {
+                return Promise.resolve();
+            }
+            return Promise.reject(new Error('Las contraseñas no coinciden.'));
+        },
+    }),
+];
+
 export const storeNameRules = (): Rule[] => [
     { required: true, message: 'El nombre de tienda es obligatorio.' },
     { min: 3, message: 'Mínimo 3 caracteres.' },
@@ -19,6 +31,10 @@ export const storeNameRules = (): Rule[] => [
 export const storePhoneRules = (): Rule[] => [
     { required: true, message: 'El teléfono es obligatorio.' },
     { pattern: /^\+?[0-9\s-]{8,20}$/, message: 'Formato de teléfono inválido.' },
+];
+
+export const roleRules = (): Rule[] => [
+    { required: true, message: 'El rol es obligatorio.' },
 ];
 
 export const requiredStringRules = (fieldName: string, min = 1, max?: number): Rule[] => {


### PR DESCRIPTION
- Create UserForm with name, email, password, password_confirmation and role fields
- Create UserModal dual-mode (create/edit) following StoreModal pattern
- Add create and update methods to UsersService
- Add confirmPasswordRules and roleRules to validationRules.ts
- Add CreateUserDto (with password_confirmation, single role as string) and UpdateUserDto types
- Add useUserForm hook with loading state and error handling (field-level + toast)
- Replace AntButton with Button wrapper for Edit action in StoreUserTable
- Add users.service.test.ts with getUsers, create, update and delete tests
- Integrate UserModal into StoreUserTable with open/close state and edit shortcut
- Password confirmation validates client-side that both fields match
- Server errors (email already exists) display inline via form.setFields