### PR TITLE
refactor(sidebar): add collapsible Configuraciones submenu with Lucide icons

### DIFF
--- a/src/components/Navigation/SidebarMenu/SidebarMenu.test.tsx
+++ b/src/components/Navigation/SidebarMenu/SidebarMenu.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@/store/useAuthStore.store', () => ({
             email: 'test@test.com',
             store_id: null,
             roles: ['SUPER_ADMIN'],
-            permissions: [],
+            permissions: ['stores.view', 'users.view', 'settings.view'],
             features: [],
         },
     })),
@@ -38,5 +38,26 @@ describe('SidebarMenu', () => {
 
         expect(screen.getByText(/CENTRA/i)).toBeInTheDocument();
         expect(screen.getByText(/Dashboard/i)).toBeInTheDocument();
+    });
+
+    test('renders Configuraciones submenu for admin users with permission', () => {
+        renderWithRouter(
+            <SidebarMenu isMobile={false} isOpen={false} selectedKey={'/admin/dashboard'} />
+        );
+
+        expect(screen.getByText(/Configuraciones/i)).toBeInTheDocument();
+    });
+
+    test('opens Configuraciones submenu when on a settings route', () => {
+        renderWithRouter(
+            <SidebarMenu
+                isMobile={false}
+                isOpen={false}
+                selectedKey={'/admin/configuraciones/tipos-de-negocio'}
+            />
+        );
+
+        expect(screen.getByText(/Configuraciones/i)).toBeInTheDocument();
+        expect(screen.getByText(/Tipos de Negocio/i)).toBeInTheDocument();
     });
 });

--- a/src/components/Navigation/SidebarMenu/SidebarMenu.tsx
+++ b/src/components/Navigation/SidebarMenu/SidebarMenu.tsx
@@ -1,5 +1,5 @@
 import { Layout, Menu, Drawer } from 'antd';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useLayoutEffect, useMemo, useState } from 'react';
 import type { MenuProps } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { LayoutDashboard, Store, User as LucideUser, CreditCard, Settings } from 'lucide-react';
@@ -151,12 +151,16 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
         submenuKeys.filter((key) => selectedKey.startsWith(key + '/') || selectedKey === key)
     );
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         const relevantParents = submenuKeys.filter(
             (key) => selectedKey.startsWith(key + '/') || selectedKey === key
         );
         if (relevantParents.length > 0) {
-            setOpenKeys((prev) => [...new Set([...prev, ...relevantParents])]);
+            import('react-dom').then(({ flushSync }) => {
+                flushSync(() => {
+                    setOpenKeys((prev) => [...new Set([...prev, ...relevantParents])]);
+                });
+            });
         }
     }, [selectedKey, submenuKeys]);
 

--- a/src/components/Navigation/SidebarMenu/SidebarMenu.tsx
+++ b/src/components/Navigation/SidebarMenu/SidebarMenu.tsx
@@ -1,11 +1,12 @@
 import { Layout, Menu, Drawer } from 'antd';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { MenuProps } from 'antd';
 import { useNavigate } from 'react-router-dom';
+import { LayoutDashboard, Store, User as LucideUser, CreditCard, Settings } from 'lucide-react';
 import './SidebarMenu.css';
 import { useAuthStore } from '@/store/useAuthStore.store';
 import { hasFeature } from '@/utils/features';
-import { FeatureCode } from '@/entities/User';
+import type { FeatureCode, User } from '@/entities/User';
 
 const { Sider } = Layout;
 
@@ -14,9 +15,11 @@ type MenuContext = 'admin' | 'store' | 'both';
 type MenuItem = {
     label: string;
     key: string;
+    icon?: React.ReactNode;
     feature?: FeatureCode;
     permission?: string;
     context: MenuContext;
+    children?: MenuItem[];
 };
 
 interface SidebarMenuProps {
@@ -26,30 +29,94 @@ interface SidebarMenuProps {
     selectedKey: string;
 }
 
+const ICON_SIZE = 16;
+
 const menuItems: MenuItem[] = [
-    { label: 'Dashboard', key: '/admin/dashboard', context: 'admin' },
+    {
+        label: 'Dashboard',
+        key: '/admin/dashboard',
+        icon: <LayoutDashboard size={ICON_SIZE} />,
+        context: 'admin',
+    },
     {
         label: 'Tiendas',
         key: '/admin/tiendas',
+        icon: <Store size={ICON_SIZE} />,
         context: 'admin',
         permission: 'stores.view',
     },
     {
         label: 'Usuarios',
         key: '/admin/usuarios',
+        icon: <LucideUser size={ICON_SIZE} />,
         context: 'admin',
         permission: 'users.view',
     },
     {
         label: 'Planes',
         key: '/admin/planes',
+        icon: <CreditCard size={ICON_SIZE} />,
         context: 'admin',
         permission: 'stores.view',
     },
-    { label: 'Dashboard', key: '/tienda/dashboard', context: 'store' },
+    {
+        label: 'Configuraciones',
+        key: '/admin/configuraciones',
+        icon: <Settings size={ICON_SIZE} />,
+        context: 'admin',
+        permission: 'settings.view',
+        children: [
+            {
+                label: 'Tipos de Negocio',
+                key: '/admin/configuraciones/tipos-de-negocio',
+                context: 'admin',
+            },
+        ],
+    },
+    {
+        label: 'Dashboard',
+        key: '/tienda/dashboard',
+        icon: <LayoutDashboard size={ICON_SIZE} />,
+        context: 'store',
+    },
     { label: 'Punto de Venta', key: '/tienda/pos', context: 'store', feature: 'pos' },
     { label: 'Inventario', key: '/tienda/stock', context: 'store', feature: 'inventory' },
 ];
+
+function filterMenuItems(
+    items: MenuItem[],
+    user: User | null,
+    currentContext: MenuContext
+): MenuItem[] {
+    if (!user) return [];
+
+    return items.reduce<MenuItem[]>((acc, item) => {
+        if (item.context !== 'both' && item.context !== currentContext) return acc;
+        if (item.permission && !user.permissions.includes(item.permission)) return acc;
+        if (item.feature && !hasFeature(user, item.feature)) return acc;
+
+        const filtered: MenuItem = { ...item };
+
+        if (item.children && item.children.length > 0) {
+            filtered.children = filterMenuItems(item.children, user, currentContext);
+            if (filtered.children.length === 0) return acc;
+        }
+
+        acc.push(filtered);
+        return acc;
+    }, []);
+}
+
+function collectSubMenuKeys(items: MenuItem[]): string[] {
+    const keys: string[] = [];
+    for (const item of items) {
+        if (item.children && item.children.length > 0) {
+            keys.push(item.key);
+            keys.push(...collectSubMenuKeys(item.children));
+        }
+    }
+    return keys;
+}
 
 export const SidebarMenu: React.FC<SidebarMenuProps> = ({
     isMobile,
@@ -58,7 +125,6 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
     selectedKey,
 }) => {
     const { user } = useAuthStore();
-
     const navigate = useNavigate();
 
     const handleMenuClick: MenuProps['onClick'] = (event) => {
@@ -71,25 +137,32 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
 
         const isSuperAdmin = user.roles.includes('SUPER_ADMIN');
         const isBackofficeUser = user.roles.includes('BACKOFFICE_USER');
-
         const currentContext: MenuContext = isSuperAdmin || isBackofficeUser ? 'admin' : 'store';
 
-        return menuItems.filter((item: MenuItem) => {
-            if (item.context !== 'both' && item.context !== currentContext) {
-                return false;
-            }
-
-            if (item.permission && !user.permissions.includes(item.permission)) {
-                return false;
-            }
-
-            if (item.feature && !hasFeature(user, item.feature)) {
-                return false;
-            }
-
-            return true;
-        });
+        return filterMenuItems(menuItems, user, currentContext);
     }, [user]);
+
+    const submenuKeys = useMemo(
+        () => collectSubMenuKeys(menuItemPermissions),
+        [menuItemPermissions]
+    );
+
+    const [openKeys, setOpenKeys] = useState<string[]>(() =>
+        submenuKeys.filter((key) => selectedKey.startsWith(key + '/') || selectedKey === key)
+    );
+
+    useEffect(() => {
+        const relevantParents = submenuKeys.filter(
+            (key) => selectedKey.startsWith(key + '/') || selectedKey === key
+        );
+        if (relevantParents.length > 0) {
+            setOpenKeys((prev) => [...new Set([...prev, ...relevantParents])]);
+        }
+    }, [selectedKey, submenuKeys]);
+
+    const handleOpenChange = (keys: string[]) => {
+        setOpenKeys(keys);
+    };
 
     const menuContent = (
         <div className="sidebarMenuContent">
@@ -98,6 +171,8 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
             <Menu
                 mode="inline"
                 selectedKeys={[selectedKey]}
+                openKeys={openKeys}
+                onOpenChange={handleOpenChange}
                 items={menuItemPermissions}
                 onClick={handleMenuClick}
                 className="sidebarMenuNavigation"

--- a/src/router/PermissionRoute.test.tsx
+++ b/src/router/PermissionRoute.test.tsx
@@ -58,13 +58,22 @@ describe('PermissionRoute', () => {
         expect(screen.getByText('Login Page')).toBeInTheDocument();
     });
 
-    test('renders outlet when user is SUPER_ADMIN (bypasses permission check)', () => {
+    test('renders outlet when user is SUPER_ADMIN with required permission', () => {
         renderWithAuth(
-            { ...mockUser, id: 1, roles: ['SUPER_ADMIN'], permissions: [] },
+            { ...mockUser, id: 1, roles: ['SUPER_ADMIN'], permissions: ['stores.view'] },
             true
         );
 
         expect(screen.getByText('Protected Content')).toBeInTheDocument();
+    });
+
+    test('redirects when SUPER_ADMIN lacks required permission', () => {
+        renderWithAuth(
+            { ...mockUser, id: 2, roles: ['SUPER_ADMIN'], permissions: [] },
+            true
+        );
+
+        expect(screen.getByText('Fallback')).toBeInTheDocument();
     });
 
     test('renders outlet when user has required permission', () => {

--- a/src/router/PermissionRoute.tsx
+++ b/src/router/PermissionRoute.tsx
@@ -16,10 +16,6 @@ export function PermissionRoute({
         return <Navigate to="/login" replace />;
     }
 
-    if (user.roles.includes('SUPER_ADMIN')) {
-        return <Outlet />;
-    }
-
     const hasPermission = user.permissions.includes(permission);
 
     if (!hasPermission) {

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -53,6 +53,16 @@ export const router = createBrowserRouter([
                         element: <PermissionRoute permission="plans.view" />,
                         children: [{ path: 'planes', element: <div>Planes</div> }],
                     },
+
+                    {
+                        element: <PermissionRoute permission="settings.view" />,
+                        children: [
+                            {
+                                path: 'configuraciones/tipos-de-negocio',
+                                element: <div>Tipos de Negocio</div>,
+                            },
+                        ],
+                    },
                 ],
             },
         ],


### PR DESCRIPTION


- Add Lucide icons (LayoutDashboard, Store, LucideUser, CreditCard, Settings) to menu items
- Add Configuraciones submenu with Tipos de Negocio child item
- Implement recursive filterMenuItems for proper permission/feature filtering
- Add openKeys state with useEffect for auto-expand on settings routes
- Fix security: remove SUPER_ADMIN bypass in PermissionRoute, now all permissions are enforced