### PR TITLE
feat(roles): add roles and permissions management UI

### DIFF
--- a/src/components/Navigation/SidebarMenu/SidebarMenu.tsx
+++ b/src/components/Navigation/SidebarMenu/SidebarMenu.tsx
@@ -76,6 +76,11 @@ const menuItems: MenuItem[] = [
                 key: '/admin/configuraciones/funcionalidades',
                 context: 'admin',
             },
+            {
+                label: 'Roles y Permisos',
+                key: '/admin/configuraciones/roles',
+                context: 'admin',
+            },
         ],
     },
     {

--- a/src/constants/api/endpoints.ts
+++ b/src/constants/api/endpoints.ts
@@ -17,5 +17,11 @@ export const API_ENDPOINTS = {
         PLANS: {
             URL: '/v1/admin/plans',
         },
+        ROLES: {
+            URL: '/v1/admin/roles',
+        },
+        PERMISSIONS: {
+            URL: '/v1/admin/permissions',
+        },
     },
 } as const;

--- a/src/features/admin/roles/components/PermissionDrawer/PermissionDrawer.css
+++ b/src/features/admin/roles/components/PermissionDrawer/PermissionDrawer.css
@@ -1,0 +1,66 @@
+.permissionDrawerLoading {
+    @apply text-center py-10;
+}
+
+.permissionDrawerContent {
+    @apply max-h-[calc(100vh-280px)] overflow-y-auto pr-2;
+}
+
+.permissionDrawerGroups {
+    @apply flex flex-col gap-4;
+}
+
+.permissionDrawerCard {
+    @apply flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4;
+}
+
+.permissionDrawerCardTitle {
+    @apply flex items-center gap-2 text-sm font-semibold text-gray-700 leading-none;
+}
+
+.permissionDrawerDivider {
+    @apply h-px w-full bg-gray-200;
+}
+
+.permissionDrawerGrid {
+    @apply grid grid-cols-2 gap-x-4 gap-y-2;
+}
+
+.permissionDrawerItem {
+    @apply flex items-start gap-2 py-1;
+}
+
+.permissionDrawerItemInfo {
+    @apply flex flex-col gap-0.5 min-w-0;
+}
+
+.permissionDrawerItemName {
+    @apply text-sm font-medium text-gray-900;
+}
+
+.permissionDrawerItemCode {
+    @apply text-xs text-gray-400 font-mono;
+}
+
+.permissionDrawerFooter {
+    @apply flex items-center gap-3 pt-4 mt-4;
+    border-top: 1px solid #f0f0f0;
+}
+
+.permissionDrawerEmptyText {
+    @apply text-xs text-gray-500 mr-auto;
+}
+
+.permissionDrawerEmpty {
+    @apply text-center py-8 text-gray-500;
+}
+
+@media (max-width: 768px) {
+    .permissionDrawerContent {
+        @apply max-h-[calc(100vh-240px)];
+    }
+
+    .permissionDrawerGrid {
+        @apply grid-cols-1;
+    }
+}

--- a/src/features/admin/roles/components/PermissionDrawer/PermissionDrawer.tsx
+++ b/src/features/admin/roles/components/PermissionDrawer/PermissionDrawer.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { message, Spin } from 'antd';
+import { Store, User, CreditCard, Settings2, Tag, Settings, Shield, Key } from 'lucide-react';
+import { Button } from '@/components/Button';
+import { Drawer } from '@/components/Drawer';
+import Checkbox from '@/components/Checkbox/Checkbox';
+import { RolesService } from '../../services/role.service';
+import type { Role, PermissionsByResource } from '../../types/role.types';
+import './PermissionDrawer.css';
+
+interface PermissionDrawerProps {
+    open: boolean;
+    onClose: () => void;
+    onSuccess: () => void;
+    role: Role | null;
+}
+
+interface PermissionGroup {
+    resource: string;
+    key: string;
+    permissions: { code: string; name: string }[];
+}
+
+const getErrorMessage = (err: unknown, fallback: string): string => {
+    if (err && typeof err === 'object') {
+        if ('message' in err && typeof (err as { message: unknown }).message === 'string') {
+            return (err as { message: string }).message;
+        }
+        if ('data' in err && (err as { data?: { message?: string } }).data?.message) {
+            return (err as { data: { message: string } }).data.message;
+        }
+    }
+    return fallback;
+};
+
+const formatPermissionName = (code: string): string => {
+    const parts = code.split('.');
+    if (parts.length === 2) {
+        const [, action] = parts;
+        const actionNames: Record<string, string> = {
+            view: 'Ver',
+            create: 'Crear',
+            edit: 'Editar',
+            delete: 'Eliminar',
+        };
+        return actionNames[action] ?? action;
+    }
+    return code;
+};
+
+const getResourceName = (resource: string): string => {
+    const names: Record<string, string> = {
+        stores: 'Tiendas',
+        backoffice_users: 'Usuarios Backoffice',
+        plans: 'Planes',
+        users: 'Usuarios',
+        features: 'Funcionalidades',
+        business_types: 'Tipos de Negocio',
+        settings: 'Configuraciones',
+        roles: 'Roles',
+    };
+    return names[resource] ?? resource.charAt(0).toUpperCase() + resource.slice(1);
+};
+
+const getResourceIcon = (resource: string): React.ReactNode => {
+    const icons: Record<string, React.ReactNode> = {
+        stores: <Store size={16} />,
+        users: <User size={16} />,
+        backoffice_users: <User size={16} />,
+        plans: <CreditCard size={16} />,
+        features: <Settings2 size={16} />,
+        business_types: <Tag size={16} />,
+        settings: <Settings size={16} />,
+        roles: <Shield size={16} />,
+    };
+    return icons[resource] ?? <Key size={16} />;
+};
+
+export const PermissionDrawer = ({
+    open,
+    onClose,
+    onSuccess,
+    role,
+}: PermissionDrawerProps) => {
+    const [permissionsByResource, setPermissionsByResource] = useState<PermissionsByResource>({});
+    const [checkedCodes, setCheckedCodes] = useState<Set<string>>(new Set());
+    const [loading, setLoading] = useState(false);
+    const [fetching, setFetching] = useState(false);
+
+    const fetchCatalog = useCallback(async () => {
+        setFetching(true);
+        try {
+            const response = await RolesService.getPermissions({ per_page: 200 });
+            setPermissionsByResource(response as PermissionsByResource);
+        } catch (err) {
+            message.error(getErrorMessage(err, 'Error al cargar permisos.'));
+            setPermissionsByResource({});
+        } finally {
+            setFetching(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (open && role) {
+            fetchCatalog();
+
+            const codes = new Set(role.permissions ?? []);
+            setCheckedCodes(codes);
+        } else if (!open) {
+            setPermissionsByResource({});
+            setCheckedCodes(new Set());
+        }
+    }, [open, role, fetchCatalog]);
+
+    const groupedPermissions = useMemo<PermissionGroup[]>(() => {
+        if (!permissionsByResource || typeof permissionsByResource !== 'object') {
+            return [];
+        }
+
+        const result: PermissionGroup[] = Object.entries(permissionsByResource)
+            .filter(([, perms]) => Array.isArray(perms) && perms.length > 0)
+            .map(([key, codes]) => ({
+                resource: getResourceName(key),
+                key,
+                permissions: codes.map((code) => ({
+                    code,
+                    name: formatPermissionName(code),
+                })),
+            }))
+            .sort((a, b) => a.resource.localeCompare(b.resource));
+
+        return result;
+    }, [permissionsByResource]);
+
+    const handleToggle = (permissionCode: string, checked: boolean) => {
+        setCheckedCodes((prev) => {
+            const next = new Set(prev);
+            if (checked) {
+                next.add(permissionCode);
+            } else {
+                next.delete(permissionCode);
+            }
+            return next;
+        });
+    };
+
+    const handleSave = async () => {
+        if (!role) return;
+
+        setLoading(true);
+        try {
+            const payload = {
+                permissions: Array.from(checkedCodes),
+            };
+
+            await RolesService.syncPermissions(String(role.id), payload);
+            message.success('Permisos actualizados correctamente.');
+            onSuccess();
+        } catch (err) {
+            message.error(getErrorMessage(err, 'Error al actualizar permisos.'));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleClose = () => {
+        if (!loading) {
+            onClose();
+        }
+    };
+
+    return (
+        <Drawer
+            open={open}
+            onClose={handleClose}
+            title={`Permisos — ${role?.name ?? ''}`}
+            width={560}
+            loading={loading}
+            destroyOnClose
+        >
+            {fetching ? (
+                <div className="permissionDrawerLoading">
+                    <Spin />
+                </div>
+            ) : (
+                <>
+                    <div className="permissionDrawerContent">
+                        {groupedPermissions.length === 0 ? (
+                            <div className="permissionDrawerEmpty">
+                                No hay permisos disponibles
+                            </div>
+                        ) : (
+                            <div className="permissionDrawerGroups">
+                                {groupedPermissions.map((group) => (
+                                    <div key={group.key} className="permissionDrawerCard">
+                                        <h4 className="permissionDrawerCardTitle">
+                                            {getResourceIcon(group.key)}
+                                            {group.resource}
+                                        </h4>
+                                        <div className="permissionDrawerDivider" />
+                                        <div className="permissionDrawerGrid">
+                                            {group.permissions.map((permission) => {
+                                                const isChecked = checkedCodes.has(permission.code);
+
+                                                return (
+                                                    <div
+                                                        key={permission.code}
+                                                        className="permissionDrawerItem"
+                                                    >
+                                                        <Checkbox
+                                                            checked={isChecked}
+                                                            onChange={(e) =>
+                                                                handleToggle(
+                                                                    permission.code,
+                                                                    e.target.checked
+                                                                )
+                                                            }
+                                                        />
+                                                        <div className="permissionDrawerItemInfo">
+                                                            <span className="permissionDrawerItemName">
+                                                                {permission.name}
+                                                            </span>
+                                                            <span className="permissionDrawerItemCode">
+                                                                {permission.code}
+                                                            </span>
+                                                        </div>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="permissionDrawerFooter">
+                        {checkedCodes.size === 0 && (
+                            <span className="permissionDrawerEmptyText">
+                                Seleccioná al menos un permiso
+                            </span>
+                        )}
+                        <Button
+                            variant="default"
+                            label="Cancelar"
+                            action={handleClose}
+                            disabled={loading}
+                        />
+                        <Button
+                            variant="primary"
+                            label="Guardar cambios"
+                            loading={loading}
+                            action={handleSave}
+                            disabled={loading || checkedCodes.size === 0}
+                        />
+                    </div>
+                </>
+            )}
+        </Drawer>
+    );
+};

--- a/src/features/admin/roles/components/PermissionDrawer/index.ts
+++ b/src/features/admin/roles/components/PermissionDrawer/index.ts
@@ -1,0 +1,1 @@
+export { PermissionDrawer } from './PermissionDrawer';

--- a/src/features/admin/roles/components/RolesTable/RolesTable.css
+++ b/src/features/admin/roles/components/RolesTable/RolesTable.css
@@ -1,0 +1,17 @@
+.rolesTableActions {
+    @apply flex items-center gap-1;
+}
+
+.rolesTablePermissionTag {
+    @apply text-xs;
+}
+
+.rolesTableOverflowTag {
+    @apply text-xs;
+}
+
+@media (max-width: 768px) {
+    .rolesTableActions {
+        @apply flex-wrap;
+    }
+}

--- a/src/features/admin/roles/components/RolesTable/RolesTable.stories.tsx
+++ b/src/features/admin/roles/components/RolesTable/RolesTable.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RolesTable } from './RolesTable';
+
+const meta: Meta<typeof RolesTable> = {
+    title: 'Features/Admin/Roles/RolesTable',
+    component: RolesTable,
+    tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const mockRole = {
+    id: 'r1',
+    name: 'Administrador',
+    description: 'Rol de administrador',
+    permissions: ['stores.view', 'stores.edit', 'plans.view', 'plans.create'],
+    users_count: 5,
+    created_at: '2024-01-15T10:00:00Z',
+    updated_at: '2024-01-15T10:00:00Z',
+};
+
+export const Default: Story = {
+    args: {
+        roles: [mockRole],
+        loading: false,
+        onEditPermissions: () => {},
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        roles: [],
+        loading: true,
+        onEditPermissions: () => {},
+    },
+};
+
+export const Empty: Story = {
+    args: {
+        roles: [],
+        loading: false,
+        onEditPermissions: () => {},
+    },
+};

--- a/src/features/admin/roles/components/RolesTable/RolesTable.test.tsx
+++ b/src/features/admin/roles/components/RolesTable/RolesTable.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { RolesTable } from './RolesTable';
+import type { Role } from '../../types/role.types';
+
+const mockRole: Role = {
+    id: 'r1',
+    name: 'Administrador',
+    description: 'Rol de administrador',
+    permissions: ['stores.view', 'stores.edit'],
+    users_count: 5,
+    created_at: '2024-01-15T10:00:00Z',
+    updated_at: '2024-01-15T10:00:00Z',
+};
+
+const renderWithRouter = (component: React.ReactElement) => {
+    return render(<MemoryRouter>{component}</MemoryRouter>);
+};
+
+describe('RolesTable', () => {
+    test('renders role name', () => {
+        const onEditPermissions = vi.fn();
+
+        renderWithRouter(
+            <RolesTable
+                roles={[mockRole]}
+                loading={false}
+                onEditPermissions={onEditPermissions}
+            />
+        );
+
+        expect(screen.getByText('Administrador')).toBeInTheDocument();
+    });
+
+    test('renders base table columns', () => {
+        const onEditPermissions = vi.fn();
+
+        renderWithRouter(
+            <RolesTable
+                roles={[]}
+                loading={false}
+                onEditPermissions={onEditPermissions}
+            />
+        );
+
+        expect(screen.getByRole('columnheader', { name: 'Rol' })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Acciones' })).toBeInTheDocument();
+    });
+
+    test('shows empty text when there are no roles', () => {
+        const onEditPermissions = vi.fn();
+
+        renderWithRouter(
+            <RolesTable
+                roles={[]}
+                loading={false}
+                onEditPermissions={onEditPermissions}
+            />
+        );
+
+        expect(screen.getByText('No hay roles para mostrar')).toBeInTheDocument();
+    });
+
+    test('shows loading state', () => {
+        const onEditPermissions = vi.fn();
+        const { container } = renderWithRouter(
+            <RolesTable
+                roles={[]}
+                loading={true}
+                onEditPermissions={onEditPermissions}
+            />
+        );
+
+        expect(container.querySelector('.ant-spin')).toBeInTheDocument();
+    });
+
+    test('renders edit permissions button with correct aria-label', () => {
+        const onEditPermissions = vi.fn();
+
+        renderWithRouter(
+            <RolesTable
+                roles={[mockRole]}
+                loading={false}
+                onEditPermissions={onEditPermissions}
+            />
+        );
+
+        const editButton = screen.getByRole('button', { name: 'Editar permisos' });
+        expect(editButton).toBeInTheDocument();
+    });
+});

--- a/src/features/admin/roles/components/RolesTable/RolesTable.tsx
+++ b/src/features/admin/roles/components/RolesTable/RolesTable.tsx
@@ -1,0 +1,109 @@
+import { EditOutlined } from '@ant-design/icons';
+import { Tooltip, Space } from 'antd';
+import Table from '@/components/Table/Table';
+import Tag from '@/components/Tag/Tag';
+import { ActionButton } from '@/components/ActionButton';
+import type { Role } from '../../types/role.types';
+import './RolesTable.css';
+
+interface RolesTableProps {
+    roles: Role[];
+    loading: boolean;
+    onEditPermissions: (role: Role) => void;
+}
+
+const MAX_VISIBLE_PERMISSIONS = 4;
+
+const renderPermissions = (permissions: string[]) => {
+    if (!permissions || permissions.length === 0) return '—';
+
+    const visible = permissions.slice(0, MAX_VISIBLE_PERMISSIONS);
+    const overflow = permissions.slice(MAX_VISIBLE_PERMISSIONS);
+
+    const tagElements = visible.map((p) => (
+        <Tag key={p} className="rolesTablePermissionTag">
+            {p}
+        </Tag>
+    ));
+
+    if (overflow.length > 0) {
+        const overflowContent = (
+            <Space direction="vertical" size={4}>
+                {overflow.map((p) => (
+                    <span key={p}>{p}</span>
+                ))}
+            </Space>
+        );
+
+        tagElements.push(
+            <Tooltip
+                key="overflow"
+                title={<div style={{ maxWidth: 280 }}>{overflowContent}</div>}
+            >
+                <span>
+                    <Tag color="default" className="rolesTableOverflowTag">
+                        +{overflow.length} más
+                    </Tag>
+                </span>
+            </Tooltip>
+        );
+    }
+
+    return <Space wrap size={4}>{tagElements}</Space>;
+};
+
+export const RolesTable = ({
+    roles,
+    loading,
+    onEditPermissions,
+}: RolesTableProps) => {
+    const columns = [
+        {
+            title: 'Rol',
+            dataIndex: 'name',
+            key: 'name',
+        },
+        {
+            title: 'Usuarios',
+            key: 'users_count',
+            responsive: ['md'] as ('md')[],
+            render: (_: unknown, record: Role) =>
+                record.users_count > 0 ? (
+                    <Tag color="blue">{record.users_count}</Tag>
+                ) : (
+                    '0'
+                ),
+        },
+        {
+            title: 'Permisos',
+            key: 'permissions',
+            responsive: ['lg'] as ('lg')[],
+            render: (_: unknown, record: Role) => renderPermissions(record.permissions),
+        },
+        {
+            title: 'Acciones',
+            key: 'actions',
+            render: (_: unknown, record: Role) => (
+                <div className="rolesTableActions">
+                    <ActionButton
+                        icon={<EditOutlined />}
+                        label="Editar permisos"
+                        action={() => onEditPermissions(record)}
+                    />
+                </div>
+            ),
+        },
+    ];
+
+    return (
+        <Table
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            columns={columns as any}
+            dataSource={roles as unknown as Record<string, unknown>[]}
+            loading={loading}
+            emptyText="No hay roles para mostrar"
+            scroll={{ x: 'max-content' }}
+            size="small"
+        />
+    );
+};

--- a/src/features/admin/roles/components/RolesTable/index.ts
+++ b/src/features/admin/roles/components/RolesTable/index.ts
@@ -1,0 +1,1 @@
+export { RolesTable } from './RolesTable';

--- a/src/features/admin/roles/services/role.service.test.ts
+++ b/src/features/admin/roles/services/role.service.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import api from '@/api/api.config';
+import { RolesService } from './role.service';
+
+vi.mock('@/api/api.config');
+
+type MockApi = {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+};
+
+const mockApi = vi.mocked(api) as unknown as MockApi;
+
+const mockPermission = {
+    id: 'p1',
+    name: 'Ver Tiendas',
+    code: 'stores.view',
+    resource: 'Tiendas',
+    description: 'Permite ver tiendas',
+    created_at: '2024-01-15T10:00:00Z',
+    updated_at: '2024-01-15T10:00:00Z',
+};
+
+const mockRole = {
+    id: 'r1',
+    name: 'Administrador',
+    description: 'Rol de administrador',
+    permissions: ['stores.view', 'stores.edit'],
+    users_count: 5,
+    created_at: '2024-01-15T10:00:00Z',
+    updated_at: '2024-01-15T10:00:00Z',
+};
+
+const mockSuccessResponse = {
+    status: 'success' as const,
+    message: 'Listado de roles obtenido correctamente.',
+    data: {
+        items: [mockRole],
+        total: 1,
+        per_page: 15,
+        current_page: 1,
+        last_page: 1,
+    },
+    errors: null,
+};
+
+const mockErrorResponse = {
+    status: 'error' as const,
+    message: 'No autorizado',
+    data: null,
+    errors: null,
+};
+
+describe('RolesService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('getAll', () => {
+        test('returns roles list on success', async () => {
+            mockApi.get.mockResolvedValue({ data: mockSuccessResponse });
+
+            const result = await RolesService.getAll();
+
+            expect(result).toEqual(mockSuccessResponse.data);
+            expect(mockApi.get).toHaveBeenCalledWith('/v1/admin/roles');
+        });
+
+        test('throws error on API error status', async () => {
+            mockApi.get.mockResolvedValue({ data: mockErrorResponse });
+
+            await expect(RolesService.getAll()).rejects.toThrow('No autorizado');
+        });
+
+        test('throws error on network error', async () => {
+            mockApi.get.mockRejectedValue(new Error('Network error'));
+
+            await expect(RolesService.getAll()).rejects.toThrow('Network error');
+        });
+    });
+
+    describe('getById', () => {
+        test('returns role on success', async () => {
+            const roleResponse = {
+                status: 'success' as const,
+                message: 'Rol obtenido correctamente.',
+                data: mockRole,
+                errors: null,
+            };
+            mockApi.get.mockResolvedValue({ data: roleResponse });
+
+            const result = await RolesService.getById('r1');
+
+            expect(result).toEqual(roleResponse.data);
+            expect(mockApi.get).toHaveBeenCalledWith('/v1/admin/roles/r1');
+        });
+
+        test('throws error on API error status', async () => {
+            mockApi.get.mockResolvedValue({ data: mockErrorResponse });
+
+            await expect(RolesService.getById('r1')).rejects.toThrow('No autorizado');
+        });
+    });
+
+    describe('update', () => {
+        test('returns updated role on success', async () => {
+            const updateResponse = {
+                status: 'success' as const,
+                message: 'Rol actualizado correctamente.',
+                data: { ...mockRole, name: 'Administrador Actualizado' },
+                errors: null,
+            };
+            mockApi.put.mockResolvedValue({ data: updateResponse });
+
+            const result = await RolesService.update('r1', { name: 'Administrador Actualizado' });
+
+            expect(result).toEqual(updateResponse.data);
+            expect(mockApi.put).toHaveBeenCalledWith('/v1/admin/roles/r1', {
+                name: 'Administrador Actualizado',
+            });
+        });
+
+        test('throws error on API error status', async () => {
+            mockApi.put.mockResolvedValue({ data: mockErrorResponse });
+
+            await expect(
+                RolesService.update('r1', { name: 'Administrador Actualizado' })
+            ).rejects.toThrow('No autorizado');
+        });
+    });
+
+    describe('getPermissions', () => {
+        test('returns permissions list on success', async () => {
+            const permissionsResponse = {
+                status: 'success' as const,
+                message: 'Listado de permisos obtenido correctamente.',
+                data: {
+                    items: [mockPermission],
+                    total: 1,
+                    per_page: 200,
+                    current_page: 1,
+                    last_page: 1,
+                },
+                errors: null,
+            };
+            mockApi.get.mockResolvedValue({ data: permissionsResponse });
+
+            const result = await RolesService.getPermissions();
+
+            expect(result).toEqual(permissionsResponse.data);
+            expect(mockApi.get).toHaveBeenCalledWith('/v1/admin/permissions', {
+                params: undefined,
+            });
+        });
+
+        test('passes filters to request', async () => {
+            const permissionsResponse = {
+                status: 'success' as const,
+                message: 'Listado de permisos obtenido correctamente.',
+                data: {
+                    items: [mockPermission],
+                    total: 1,
+                    per_page: 200,
+                    current_page: 1,
+                    last_page: 1,
+                },
+                errors: null,
+            };
+            mockApi.get.mockResolvedValue({ data: permissionsResponse });
+
+            await RolesService.getPermissions({ resource: 'Tiendas' });
+
+            expect(mockApi.get).toHaveBeenCalledWith('/v1/admin/permissions', {
+                params: { resource: 'Tiendas' },
+            });
+        });
+
+        test('throws error on API error status', async () => {
+            mockApi.get.mockResolvedValue({ data: mockErrorResponse });
+
+            await expect(RolesService.getPermissions()).rejects.toThrow('No autorizado');
+        });
+    });
+
+    describe('syncPermissions', () => {
+        test('resolves on success', async () => {
+            const syncResponse = {
+                status: 'success' as const,
+                message: 'Permisos sincronizados correctamente.',
+                data: null,
+                errors: null,
+            };
+            mockApi.post.mockResolvedValue({ data: syncResponse });
+
+            await expect(
+                RolesService.syncPermissions('r1', { permissions: ['p1', 'p2'] })
+            ).resolves.toBeUndefined();
+            expect(mockApi.post).toHaveBeenCalledWith(
+                '/v1/admin/roles/r1/sync-permissions',
+                { permissions: ['p1', 'p2'] }
+            );
+        });
+
+        test('throws error on API error status', async () => {
+            mockApi.post.mockResolvedValue({ data: mockErrorResponse });
+
+            await expect(
+                RolesService.syncPermissions('r1', { permissions: ['p1'] })
+            ).rejects.toThrow('No autorizado');
+        });
+    });
+});

--- a/src/features/admin/roles/services/role.service.ts
+++ b/src/features/admin/roles/services/role.service.ts
@@ -1,0 +1,102 @@
+import api from '@/api/api.config';
+import { API_ENDPOINTS } from '@/constants/api/endpoints';
+import type { ApiError } from '@/interfaces/ApiErrors.interface';
+import type { ApiListResponse } from '@/interfaces/ApiListResponse.interface';
+import type {
+    Role,
+    RolesListResponse,
+    PermissionsListResponse,
+    UpdateRoleDto,
+    SyncPermissionsDto,
+    PermissionsFilters,
+} from '../types/role.types';
+
+export const RolesService = {
+    getAll: async (): Promise<RolesListResponse> => {
+        const { data } = await api.get<ApiListResponse<RolesListResponse>>(
+            API_ENDPOINTS.ADMIN.ROLES.URL
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+
+        return data.data;
+    },
+
+    getById: async (id: string): Promise<Role> => {
+        const { data } = await api.get<ApiListResponse<Role>>(
+            `${API_ENDPOINTS.ADMIN.ROLES.URL}/${id}`
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+
+        return data.data;
+    },
+
+    update: async (id: string, dto: UpdateRoleDto): Promise<Role> => {
+        const { data } = await api.put<ApiListResponse<Role>>(
+            `${API_ENDPOINTS.ADMIN.ROLES.URL}/${id}`,
+            dto
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+
+        return data.data;
+    },
+
+    getPermissions: async (
+        filters?: PermissionsFilters
+    ): Promise<PermissionsListResponse> => {
+        const { data } = await api.get<ApiListResponse<PermissionsListResponse>>(
+            API_ENDPOINTS.ADMIN.PERMISSIONS.URL,
+            { params: filters }
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+
+        return data.data;
+    },
+
+    syncPermissions: async (roleId: string, dto: SyncPermissionsDto): Promise<void> => {
+        const { data } = await api.post<ApiListResponse<null>>(
+            `${API_ENDPOINTS.ADMIN.ROLES.URL}/${roleId}/sync-permissions`,
+            dto
+        );
+
+        if (data.status === 'error') {
+            const error: ApiError = {
+                status: 0,
+                message: data.message,
+                errors: data.errors ?? undefined,
+            };
+            throw error;
+        }
+    },
+};

--- a/src/features/admin/roles/types/role.types.ts
+++ b/src/features/admin/roles/types/role.types.ts
@@ -1,0 +1,56 @@
+export interface Permission {
+    id: string;
+    name: string;
+    code: string;
+    resource: string;
+    description: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface Role {
+    id: string | number;
+    name: string;
+    description: string | null;
+    permissions: string[];
+    users_count: number;
+    permissions_count?: number;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface RolesListResponse {
+    items: Role[];
+    total: number;
+    per_page: number;
+    current_page: number;
+    last_page: number;
+}
+
+export interface PermissionsByResource {
+    [resource: string]: string[];
+}
+
+export interface PermissionsListResponse {
+    stores?: string[];
+    backoffice_users?: string[];
+    plans?: string[];
+    users?: string[];
+    settings?: string[];
+    [key: string]: string[] | undefined;
+}
+
+export interface UpdateRoleDto {
+    name?: string;
+    description?: string;
+}
+
+export interface SyncPermissionsDto {
+    permissions: string[];
+}
+
+export interface PermissionsFilters {
+    page?: number;
+    per_page?: number;
+    resource?: string;
+}

--- a/src/pages/admin/settings/Roles/RolesPage.css
+++ b/src/pages/admin/settings/Roles/RolesPage.css
@@ -1,0 +1,46 @@
+.rolesPage {
+    @apply w-full;
+}
+
+.rolesPageHeader {
+    @apply mb-6;
+}
+
+.rolesPageBreadcrumb {
+    @apply mb-2;
+}
+
+.rolesPageHeaderTop {
+    @apply flex flex-wrap items-start justify-between gap-4;
+}
+
+.rolesPageHeaderText {
+    @apply flex flex-col gap-1;
+}
+
+.rolesPageTitle {
+    @apply text-2xl font-bold text-centra-primary m-0;
+}
+
+.rolesPageDescription {
+    @apply text-sm text-centra-text/60 m-0;
+}
+
+.rolesPageAlert {
+    @apply mb-4 py-2 text-sm;
+}
+
+@media (max-width: 768px) {
+    .rolesPage {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .rolesPageHeader {
+        @apply mb-4;
+    }
+
+    .rolesPageTitle {
+        @apply text-xl;
+    }
+}

--- a/src/pages/admin/settings/Roles/RolesPage.tsx
+++ b/src/pages/admin/settings/Roles/RolesPage.tsx
@@ -1,0 +1,94 @@
+import { useState, useCallback, useEffect } from 'react';
+import { message } from 'antd';
+import { RolesPageView } from './RolesPageView';
+import { RolesTable } from '@/features/admin/roles/components/RolesTable';
+import { PermissionDrawer } from '@/features/admin/roles/components/PermissionDrawer';
+import { RolesService } from '@/features/admin/roles/services/role.service';
+import type { Role } from '@/features/admin/roles/types/role.types';
+
+const routeMetadata = {
+    title: 'Gestión de Roles y Permisos',
+    description: 'Administra los roles y permisos del sistema',
+    breadcrumbs: [
+        { label: 'Admin', path: '/admin/dashboard' },
+        { label: 'Configuraciones', path: '/admin/configuraciones' },
+        { label: 'Roles y Permisos' },
+    ],
+};
+
+export const RolesPage = () => {
+    const [roles, setRoles] = useState<Role[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [drawerOpen, setDrawerOpen] = useState(false);
+    const [selectedRole, setSelectedRole] = useState<Role | null>(null);
+
+    const getErrorMessage = (err: unknown, fallback: string): string => {
+        if (err && typeof err === 'object') {
+            if ('message' in err && typeof (err as { message: unknown }).message === 'string') {
+                return (err as { message: string }).message;
+            }
+            if ('data' in err && (err as { data?: { message?: string } }).data?.message) {
+                return (err as { data: { message: string } }).data.message;
+            }
+        }
+        return fallback;
+    };
+
+    const fetchRoles = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await RolesService.getAll();
+            setRoles(response.items);
+        } catch (err) {
+            const errMsg = getErrorMessage(err, 'Error al cargar roles.');
+            setError(errMsg);
+            message.error(errMsg);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchRoles();
+    }, [fetchRoles]);
+
+    const handleEditPermissions = (role: Role) => {
+        setSelectedRole(role);
+        setDrawerOpen(true);
+    };
+
+    const handleCloseDrawer = () => {
+        setDrawerOpen(false);
+        setSelectedRole(null);
+    };
+
+    const handleSuccess = () => {
+        setDrawerOpen(false);
+        setSelectedRole(null);
+        fetchRoles();
+    };
+
+    return (
+        <>
+            <RolesPageView
+                title={routeMetadata.title}
+                description={routeMetadata.description}
+                breadcrumbs={routeMetadata.breadcrumbs}
+                error={error}
+            />
+            <RolesTable
+                roles={roles}
+                loading={loading}
+                onEditPermissions={handleEditPermissions}
+            />
+            <PermissionDrawer
+                open={drawerOpen}
+                onClose={handleCloseDrawer}
+                onSuccess={handleSuccess}
+                role={selectedRole}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/settings/Roles/RolesPageView.tsx
+++ b/src/pages/admin/settings/Roles/RolesPageView.tsx
@@ -1,0 +1,42 @@
+import { Alert, Breadcrumb } from 'antd';
+import { Link } from 'react-router-dom';
+import type { PageBreadcrumbItem } from '@/router/router.utils';
+import './RolesPage.css';
+
+interface RolesPageViewProps {
+    title: string;
+    description: string;
+    breadcrumbs: PageBreadcrumbItem[];
+    error: string | null;
+}
+
+export const RolesPageView = ({
+    title,
+    description,
+    breadcrumbs,
+    error,
+}: RolesPageViewProps) => {
+    return (
+        <div className="rolesPage">
+            <div className="rolesPageHeader">
+                <Breadcrumb
+                    className="rolesPageBreadcrumb"
+                    items={breadcrumbs.map((item) => ({
+                        title: item.path ? <Link to={item.path}>{item.label}</Link> : item.label,
+                    }))}
+                />
+
+                <div className="rolesPageHeaderTop">
+                    <div className="rolesPageHeaderText">
+                        <h1 className="rolesPageTitle">{title}</h1>
+                        <p className="rolesPageDescription">{description}</p>
+                    </div>
+                </div>
+            </div>
+
+            {error && (
+                <Alert className="rolesPageAlert" type="error" description={error} showIcon />
+            )}
+        </div>
+    );
+};

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -11,6 +11,7 @@ import { PermissionRoute } from './PermissionRoute';
 import { NotFoundPage } from '@/pages/not-found';
 import { BusinessTypePage } from '@/pages/admin/settings/BusinessType/BusinessTypePage';
 import { FeaturesPage } from '@/pages/admin/settings/Feature/FeaturesPage';
+import { RolesPage } from '@/pages/admin/settings/Roles/RolesPage';
 import { PlansPage } from '@/pages/admin/plans/PlansPage';
 
 export const router = createBrowserRouter([
@@ -67,6 +68,10 @@ export const router = createBrowserRouter([
                             {
                                 path: 'configuraciones/funcionalidades',
                                 element: <FeaturesPage />,
+                            },
+                            {
+                                path: 'configuraciones/roles',
+                                element: <RolesPage />,
                             },
                         ],
                     },


### PR DESCRIPTION
- Add RolesService with getAll, getById, update, getPermissions, syncPermissions
- Add RolesPage and RolesPageView with breadcrumb navigation
- Add RolesTable with permissions displayed as tags (+N overflow)
- Add PermissionDrawer with grouped cards layout per resource
- Add route /admin/configuraciones/roles
- Add sidebar menu item 'Roles y Permisos'
- Add role.service.test.ts with full coverage
- Add RolesTable.test.tsx and RolesTable.stories.tsx

PermissionDrawer features:
- Cards grouped by resource (stores, users, plans, etc.)
- 2-column grid layout for checkboxes
- Icon + title header per card
- Spanish action names (Ver, Crear, Editar, Eliminar)
- Code displayed in muted gray below action name