### PR TITLE
feat(permissions): add granular access control to backoffice UI

### DIFF
--- a/src/components/auth/CanDo.tsx
+++ b/src/components/auth/CanDo.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { usePermissions } from '@/hooks/usePermissions';
+
+interface CanDoProps {
+    permission: string;
+    children: ReactNode;
+    fallback?: ReactNode;
+}
+
+export const CanDo = ({ permission, children, fallback = null }: CanDoProps) => {
+    const { can } = usePermissions();
+
+    if (!can(permission)) {
+        return <>{fallback}</>;
+    }
+
+    return <>{children}</>;
+};

--- a/src/features/admin/business-types/components/BusinessTypesTable/BusinessTypesTable.tsx
+++ b/src/features/admin/business-types/components/BusinessTypesTable/BusinessTypesTable.tsx
@@ -3,6 +3,7 @@ import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
 import { Tag } from '@/components/Tag';
 import Table from '@/components/Table/Table';
+import { CanDo } from '@/components/auth/CanDo';
 import { useBusinessTypesContext } from '../../hooks/useBusinessTypesContext';
 import type { BusinessType } from '../../types/business-type.types';
 import './BusinessTypesTable.css';
@@ -38,22 +39,26 @@ export const BusinessTypesTable = ({ onEdit }: BusinessTypesTableProps) => {
             key: 'actions',
             render: (_: unknown, record: BusinessType) => (
                 <div className="businessTypesTableActions">
-                    <Button
-                        variant="text"
-                        size="small"
-                        icon={<EditOutlined />}
-                        action={() => onEdit(record)}
-                    />
-                    <Popconfirm
-                        title="¿Eliminar tipo de negocio?"
-                        description="Esta acción no se puede deshacer."
-                        onConfirm={() => deleteBusinessType(record.id)}
-                        okText="Eliminar"
-                        cancelText="Cancelar"
-                        okButtonProps={{ danger: true }}
-                    >
-                        <AntButton type="text" danger size="small" icon={<DeleteOutlined />} />
-                    </Popconfirm>
+                    <CanDo permission="settings.edit">
+                        <Button
+                            variant="text"
+                            size="small"
+                            icon={<EditOutlined />}
+                            action={() => onEdit(record)}
+                        />
+                    </CanDo>
+                    <CanDo permission="settings.edit">
+                        <Popconfirm
+                            title="¿Eliminar tipo de negocio?"
+                            description="Esta acción no se puede deshacer."
+                            onConfirm={() => deleteBusinessType(record.id)}
+                            okText="Eliminar"
+                            cancelText="Cancelar"
+                            okButtonProps={{ danger: true }}
+                        >
+                            <AntButton type="text" danger size="small" icon={<DeleteOutlined />} />
+                        </Popconfirm>
+                    </CanDo>
                 </div>
             ),
         },

--- a/src/features/admin/features/components/FeaturesTable/FeaturesTable.tsx
+++ b/src/features/admin/features/components/FeaturesTable/FeaturesTable.tsx
@@ -3,6 +3,7 @@ import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
 import { Tag } from '@/components/Tag';
 import Table from '@/components/Table/Table';
+import { CanDo } from '@/components/auth/CanDo';
 import { useFeaturesContext } from '../../hooks/useFeaturesContext';
 import type { Feature } from '../../types/feature.types';
 import './FeaturesTable.css';
@@ -36,22 +37,26 @@ export const FeaturesTable = ({ onEdit }: FeaturesTableProps) => {
             key: 'actions',
             render: (_: unknown, record: Feature) => (
                 <div className="featuresTableActions">
-                    <Button
-                        variant="text"
-                        size="small"
-                        icon={<EditOutlined />}
-                        action={() => onEdit(record)}
-                    />
-                    <Popconfirm
-                        title="¿Eliminar funcionalidad?"
-                        description="Esta acción no se puede deshacer."
-                        onConfirm={() => deleteFeature(record.id)}
-                        okText="Eliminar"
-                        cancelText="Cancelar"
-                        okButtonProps={{ danger: true }}
-                    >
-                        <AntButton type="text" danger size="small" icon={<DeleteOutlined />} />
-                    </Popconfirm>
+                    <CanDo permission="settings.edit">
+                        <Button
+                            variant="text"
+                            size="small"
+                            icon={<EditOutlined />}
+                            action={() => onEdit(record)}
+                        />
+                    </CanDo>
+                    <CanDo permission="settings.edit">
+                        <Popconfirm
+                            title="¿Eliminar funcionalidad?"
+                            description="Esta acción no se puede deshacer."
+                            onConfirm={() => deleteFeature(record.id)}
+                            okText="Eliminar"
+                            cancelText="Cancelar"
+                            okButtonProps={{ danger: true }}
+                        >
+                            <AntButton type="text" danger size="small" icon={<DeleteOutlined />} />
+                        </Popconfirm>
+                    </CanDo>
                 </div>
             ),
         },

--- a/src/features/admin/plans/components/PlansTable/PlansTable.tsx
+++ b/src/features/admin/plans/components/PlansTable/PlansTable.tsx
@@ -3,6 +3,7 @@ import { Popconfirm, Button as AntButton, Tooltip, Space } from 'antd';
 import Table from '@/components/Table/Table';
 import Tag from '@/components/Tag/Tag';
 import { ActionButton } from '@/components/ActionButton';
+import { CanDo } from '@/components/auth/CanDo';
 import { usePlansContext } from '../../hooks/usePlansContext';
 import type { Plan, PlanFeature } from '../../types/plan.types';
 
@@ -117,31 +118,37 @@ export const PlansTable = ({ onEdit, onManageFeatures, onDelete }: PlansTablePro
             key: 'actions',
             render: (_: unknown, record: Plan) => (
                 <div className="flex items-center gap-1">
-                    <ActionButton
-                        icon={<EditOutlined />}
-                        label="Editar"
-                        action={() => onEdit(record)}
-                    />
-                    <ActionButton
-                        icon={<SettingOutlined />}
-                        label="Gestionar funcionalidades"
-                        action={() => onManageFeatures(record)}
-                    />
-                    <Popconfirm
-                        title="¿Eliminar plan?"
-                        description={`¿Estás seguro de eliminar "${record.name}"?`}
-                        onConfirm={() => onDelete(record)}
-                        okText="Eliminar"
-                        cancelText="Cancelar"
-                        okButtonProps={{ danger: true }}
-                    >
-                        <AntButton
-                            type="text"
-                            danger
-                            icon={<DeleteOutlined />}
-                            aria-label="Eliminar"
+                    <CanDo permission="plans.edit">
+                        <ActionButton
+                            icon={<EditOutlined />}
+                            label="Editar"
+                            action={() => onEdit(record)}
                         />
-                    </Popconfirm>
+                    </CanDo>
+                    <CanDo permission="plans.edit">
+                        <ActionButton
+                            icon={<SettingOutlined />}
+                            label="Gestionar funcionalidades"
+                            action={() => onManageFeatures(record)}
+                        />
+                    </CanDo>
+                    <CanDo permission="plans.delete">
+                        <Popconfirm
+                            title="¿Eliminar plan?"
+                            description={`¿Estás seguro de eliminar "${record.name}"?`}
+                            onConfirm={() => onDelete(record)}
+                            okText="Eliminar"
+                            cancelText="Cancelar"
+                            okButtonProps={{ danger: true }}
+                        >
+                            <AntButton
+                                type="text"
+                                danger
+                                icon={<DeleteOutlined />}
+                                aria-label="Eliminar"
+                            />
+                        </Popconfirm>
+                    </CanDo>
                 </div>
             ),
         },

--- a/src/features/admin/roles/components/RolesTable/RolesTable.test.tsx
+++ b/src/features/admin/roles/components/RolesTable/RolesTable.test.tsx
@@ -5,6 +5,16 @@ import { MemoryRouter } from 'react-router-dom';
 import { RolesTable } from './RolesTable';
 import type { Role } from '../../types/role.types';
 
+interface TestGlobal {
+    __permissions?: string[];
+}
+
+vi.mock('@/hooks/usePermissions', () => {
+    return {
+        usePermissions: vi.fn(() => ({ can: (permission: string) => (globalThis as TestGlobal).__permissions?.includes(permission) ?? false })),
+    };
+});
+
 const mockRole: Role = {
     id: 'r1',
     name: 'Administrador',
@@ -20,6 +30,14 @@ const renderWithRouter = (component: React.ReactElement) => {
 };
 
 describe('RolesTable', () => {
+    beforeEach(() => {
+        (globalThis as TestGlobal).__permissions = ['roles.edit'];
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     test('renders role name', () => {
         const onEditPermissions = vi.fn();
 

--- a/src/features/admin/roles/components/RolesTable/RolesTable.tsx
+++ b/src/features/admin/roles/components/RolesTable/RolesTable.tsx
@@ -3,6 +3,7 @@ import { Tooltip, Space } from 'antd';
 import Table from '@/components/Table/Table';
 import Tag from '@/components/Tag/Tag';
 import { ActionButton } from '@/components/ActionButton';
+import { CanDo } from '@/components/auth/CanDo';
 import type { Role } from '../../types/role.types';
 import './RolesTable.css';
 
@@ -85,11 +86,13 @@ export const RolesTable = ({
             key: 'actions',
             render: (_: unknown, record: Role) => (
                 <div className="rolesTableActions">
-                    <ActionButton
-                        icon={<EditOutlined />}
-                        label="Editar permisos"
-                        action={() => onEditPermissions(record)}
-                    />
+                    <CanDo permission="roles.edit">
+                        <ActionButton
+                            icon={<EditOutlined />}
+                            label="Editar permisos"
+                            action={() => onEditPermissions(record)}
+                        />
+                    </CanDo>
                 </div>
             ),
         },

--- a/src/features/admin/stores/components/StoresTable/StoresTable.tsx
+++ b/src/features/admin/stores/components/StoresTable/StoresTable.tsx
@@ -2,6 +2,7 @@ import { EyeOutlined, EditOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import Table from '@/components/Table/Table';
 import { ActionButton } from '@/components/ActionButton';
+import { CanDo } from '@/components/auth/CanDo';
 import { useStoresContext } from '@/features/admin/stores/hooks/useStoresContext';
 import { formatDate } from '@/utils/formatDate';
 import type { Store } from '@/features/admin/stores/types/store.types';
@@ -64,16 +65,20 @@ export const StoresTable = ({ onEdit }: StoresTableProps) => {
             key: 'actions',
             render: (_: unknown, record: Store) => (
                 <div className="storesTableActions">
-                    <ActionButton
-                        icon={<EyeOutlined />}
-                        label="Ver"
-                        action={() => navigate(`/admin/tiendas/${record.id}`)}
-                    />
-                    <ActionButton
-                        icon={<EditOutlined />}
-                        label="Editar"
-                        action={() => onEdit(record)}
-                    />
+                    <CanDo permission="stores.view">
+                        <ActionButton
+                            icon={<EyeOutlined />}
+                            label="Ver"
+                            action={() => navigate(`/admin/tiendas/${record.id}`)}
+                        />
+                    </CanDo>
+                    <CanDo permission="stores.edit">
+                        <ActionButton
+                            icon={<EditOutlined />}
+                            label="Editar"
+                            action={() => onEdit(record)}
+                        />
+                    </CanDo>
                 </div>
             ),
         },

--- a/src/features/admin/users/components/UsersTable/UsersTable.tsx
+++ b/src/features/admin/users/components/UsersTable/UsersTable.tsx
@@ -3,6 +3,7 @@ import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
 import { Tag } from '@/components/Tag';
 import Table from '@/components/Table/Table';
+import { CanDo } from '@/components/auth/CanDo';
 import { useUsersContext } from '../../hooks/useUsersContext';
 import type { User } from '@/entities/User';
 import './UsersTable.css';
@@ -52,22 +53,26 @@ export const UsersTable = ({ onEdit, onDelete }: UsersTableProps) => {
             key: 'actions',
             render: (_: unknown, record: User) => (
                 <div className="usersTableActions">
-                    <Button
-                        variant="text"
-                        size="small"
-                        icon={<EditOutlined />}
-                        action={() => onEdit(record)}
-                    />
-                    <Popconfirm
-                        title="¿Eliminar usuario?"
-                        description="Esta acción no se puede deshacer."
-                        onConfirm={() => onDelete(record.id)}
-                        okText="Eliminar"
-                        cancelText="Cancelar"
-                        okButtonProps={{ danger: true }}
-                    >
-                        <AntButton type="text" danger size="small" icon={<DeleteOutlined />} />
-                    </Popconfirm>
+                    <CanDo permission="users.edit">
+                        <Button
+                            variant="text"
+                            size="small"
+                            icon={<EditOutlined />}
+                            action={() => onEdit(record)}
+                        />
+                    </CanDo>
+                    <CanDo permission="users.delete">
+                        <Popconfirm
+                            title="¿Eliminar usuario?"
+                            description="Esta acción no se puede deshacer."
+                            onConfirm={() => onDelete(record.id)}
+                            okText="Eliminar"
+                            cancelText="Cancelar"
+                            okButtonProps={{ danger: true }}
+                        >
+                            <AntButton type="text" danger size="small" icon={<DeleteOutlined />} />
+                        </Popconfirm>
+                    </CanDo>
                 </div>
             ),
         },

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,0 +1,11 @@
+import { useAuthStore } from '@/store/useAuthStore.store';
+
+export const usePermissions = () => {
+    const user = useAuthStore((state) => state.user);
+
+    const can = (permission: string): boolean => {
+        return user?.permissions?.includes(permission) ?? false;
+    };
+
+    return { can };
+};

--- a/src/pages/admin/plans/PlansPageView.tsx
+++ b/src/pages/admin/plans/PlansPageView.tsx
@@ -2,6 +2,7 @@ import { Alert, Breadcrumb } from 'antd';
 import { Link } from 'react-router-dom';
 import { PlusOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
+import { CanDo } from '@/components/auth/CanDo';
 import { PlansTable } from '@/features/admin/plans/components/PlansTable';
 import type { PageBreadcrumbItem } from '@/router/router.utils';
 import type { Plan } from '@/features/admin/plans/types/plan.types';
@@ -42,12 +43,14 @@ export const PlansPageView = ({
                         <h1 className="m-0 text-2xl font-semibold leading-tight">{title}</h1>
                         <p className="mt-1 text-[#666] text-sm">{description}</p>
                     </div>
-                    <Button
-                        variant="primary"
-                        label="Crear Plan"
-                        icon={<PlusOutlined />}
-                        action={onCreate}
-                    />
+                    <CanDo permission="plans.create">
+                        <Button
+                            variant="primary"
+                            label="Crear Plan"
+                            icon={<PlusOutlined />}
+                            action={onCreate}
+                        />
+                    </CanDo>
                 </div>
             </div>
 

--- a/src/pages/admin/settings/BusinessType/BusinessTypesPage.test.tsx
+++ b/src/pages/admin/settings/BusinessType/BusinessTypesPage.test.tsx
@@ -7,6 +7,15 @@ import { BusinessTypesProvider } from '@/features/admin/business-types/contexts/
 import type { UseBusinessTypesReturn } from '@/features/admin/business-types/hooks/useBusinessTypes';
 import type { BusinessType } from '@/features/admin/business-types/types/business-type.types';
 
+const mockBusinessType: BusinessType = {
+    id: 1,
+    name: 'Ferretería',
+    description: 'Businesses that sell hardware and tools',
+    status: 'active',
+    created_at: '2026-04-07T22:00:06.000000Z',
+    updated_at: '2026-04-07T22:00:06.000000Z',
+};
+
 const createMockState = (overrides: Partial<UseBusinessTypesReturn> = {}): UseBusinessTypesReturn => ({
     businessTypes: [],
     loading: false,
@@ -25,16 +34,26 @@ const renderWithProvider = (ui: React.ReactElement) => {
     );
 };
 
-const mockBusinessType: BusinessType = {
-    id: 1,
-    name: 'Ferretería',
-    description: 'Businesses that sell hardware and tools',
-    status: 'active',
-    created_at: '2026-04-07T22:00:06.000000Z',
-    updated_at: '2026-04-07T22:00:06.000000Z',
+const mockCanFn = (permissions: string[]) => {
+    (globalThis as Record<string, unknown>).__testPermissions = permissions;
 };
 
 describe('BusinessTypesPage', () => {
+    beforeAll(() => {
+        vi.mock('@/hooks/usePermissions', () => ({
+            usePermissions: vi.fn(() => ({
+                can: (permission: string) => {
+                    const permissions = (globalThis as Record<string, unknown>).__testPermissions as string[] | undefined;
+                    return permissions?.includes(permission) ?? false;
+                },
+            })),
+        }));
+    });
+
+    beforeEach(() => {
+        mockCanFn(['settings.view', 'settings.edit']);
+    });
+
     test('renders the page header and breadcrumb', () => {
         renderWithProvider(
             <BusinessTypesPageView

--- a/src/pages/admin/settings/BusinessType/BusinessTypesPageView.tsx
+++ b/src/pages/admin/settings/BusinessType/BusinessTypesPageView.tsx
@@ -2,6 +2,7 @@ import { Alert, Breadcrumb } from 'antd';
 import { Link } from 'react-router-dom';
 import { PlusOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
+import { CanDo } from '@/components/auth/CanDo';
 import { BusinessTypeSearchBar } from '@/features/admin/business-types/components/BusinessTypeSearchBar';
 import { BusinessTypesTable } from '@/features/admin/business-types/components/BusinessTypesTable';
 import type { PageBreadcrumbItem } from '@/router/router.utils';
@@ -43,12 +44,14 @@ export const BusinessTypesPageView = ({
                         </h1>
                         <p className="businessTypesPageDescription">{description}</p>
                     </div>
-                    <Button
-                        variant="primary"
-                        label="Nuevo Tipo de Negocio"
-                        icon={<PlusOutlined />}
-                        action={onCreate}
-                    />
+                    <CanDo permission="settings.edit">
+                        <Button
+                            variant="primary"
+                            label="Nuevo Tipo de Negocio"
+                            icon={<PlusOutlined />}
+                            action={onCreate}
+                        />
+                    </CanDo>
                 </div>
             </div>
 

--- a/src/pages/admin/settings/Feature/FeaturesPageView.tsx
+++ b/src/pages/admin/settings/Feature/FeaturesPageView.tsx
@@ -2,6 +2,7 @@ import { Alert, Breadcrumb } from 'antd';
 import { Link } from 'react-router-dom';
 import { PlusOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
+import { CanDo } from '@/components/auth/CanDo';
 import { FeatureSearchBar } from '@/features/admin/features/components/FeatureSearchBar';
 import { FeaturesTable } from '@/features/admin/features/components/FeaturesTable';
 import type { PageBreadcrumbItem } from '@/router/router.utils';
@@ -43,12 +44,14 @@ export const FeaturesPageView = ({
                         </h1>
                         <p className="featuresPageDescription">{description}</p>
                     </div>
-                    <Button
-                        variant="primary"
-                        label="Nueva Funcionalidad"
-                        icon={<PlusOutlined />}
-                        action={onCreate}
-                    />
+                    <CanDo permission="settings.edit">
+                        <Button
+                            variant="primary"
+                            label="Nueva Funcionalidad"
+                            icon={<PlusOutlined />}
+                            action={onCreate}
+                        />
+                    </CanDo>
                 </div>
             </div>
 

--- a/src/pages/admin/stores/StoresPage.tsx
+++ b/src/pages/admin/stores/StoresPage.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { StoresPageView } from './StoresPageView';
 import { StoreModal } from '@/features/admin/stores/components/StoreModal';
 import { useStores } from '@/features/admin/stores/hooks/useStores';
-import { useAuthStore } from '@/store/useAuthStore.store';
 import { StoresProvider } from '@/features/admin/stores/contexts/StoresProvider';
 import type { Store } from '@/features/admin/stores/types/store.types';
+import { usePermissions } from '@/hooks/usePermissions';
 
 const routeMetadata = {
     title: 'Gestión de Tiendas',
@@ -17,8 +17,8 @@ const routeMetadata = {
 
 export const StoresPage = () => {
     const storesState = useStores();
-    const { user } = useAuthStore();
-    const canCreateStore = user?.permissions.includes('stores.create') ?? false;
+    const { can } = usePermissions();
+    const canCreateStore = can('stores.create');
 
     const [modalOpen, setModalOpen] = useState(false);
     const [selectedStore, setSelectedStore] = useState<Store | undefined>(undefined);

--- a/src/pages/admin/stores/StoresPageView.tsx
+++ b/src/pages/admin/stores/StoresPageView.tsx
@@ -2,6 +2,7 @@ import { Alert, Breadcrumb } from 'antd';
 import { Link } from 'react-router-dom';
 import { PlusOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
+import { CanDo } from '@/components/auth/CanDo';
 import { StoreSearchBar } from '@/features/admin/stores/components/StoreSearchBar';
 import { StoresTable } from '@/features/admin/stores/components/StoresTable';
 import type { PageBreadcrumbItem } from '@/router/router.utils';
@@ -46,12 +47,14 @@ export const StoresPageView = ({
                         <p className="storesPageDescription">{description}</p>
                     </div>
                     {canCreateStore && (
-                        <Button
-                            variant="primary"
-                            label="Nueva Tienda"
-                            icon={<PlusOutlined />}
-                            action={onCreate}
-                        />
+                        <CanDo permission="stores.create">
+                            <Button
+                                variant="primary"
+                                label="Nueva Tienda"
+                                icon={<PlusOutlined />}
+                                action={onCreate}
+                            />
+                        </CanDo>
                     )}
                 </div>
             </div>

--- a/src/pages/admin/users/UsersPage.test.tsx
+++ b/src/pages/admin/users/UsersPage.test.tsx
@@ -6,6 +6,17 @@ import { UsersProvider } from '@/features/admin/users/contexts/UsersProvider';
 import type { UseUsersReturn } from '@/features/admin/users/hooks/useUsers';
 import type { User } from '@/entities/User';
 
+const mockUser: User = {
+    id: 1,
+    name: 'Juan Pérez',
+    email: 'juan@centra.com',
+    store_id: 1,
+    store: { id: '1', name: 'Ferretería Central' },
+    roles: ['STORE_ADMIN'],
+    permissions: ['users.view'],
+    features: ['pos'],
+};
+
 const createMockUsersState = (overrides: Partial<UseUsersReturn> = {}): UseUsersReturn => ({
     users: [],
     loading: false,
@@ -26,18 +37,26 @@ const renderWithProvider = (ui: React.ReactElement) => {
     );
 };
 
-const mockUser: User = {
-    id: 1,
-    name: 'Juan Pérez',
-    email: 'juan@centra.com',
-    store_id: 1,
-    store: { id: '1', name: 'Ferretería Central' },
-    roles: ['STORE_ADMIN'],
-    permissions: ['users.view'],
-    features: ['pos'],
+const mockCanFn = (permissions: string[]) => {
+    (globalThis as Record<string, unknown>).__testPermissions = permissions;
 };
 
 describe('UsersPage', () => {
+    beforeAll(() => {
+        vi.mock('@/hooks/usePermissions', () => ({
+            usePermissions: vi.fn(() => ({
+                can: (permission: string) => {
+                    const permissions = (globalThis as Record<string, unknown>).__testPermissions as string[] | undefined;
+                    return permissions?.includes(permission) ?? false;
+                },
+            })),
+        }));
+    });
+
+    beforeEach(() => {
+        mockCanFn(['users.view']);
+    });
+
     test('renders the page header and breadcrumb', () => {
         renderWithProvider(
             <UsersPageView
@@ -94,6 +113,8 @@ describe('UsersPage', () => {
     });
 
     test('shows create button when canCreateUser is true', () => {
+        mockCanFn(['users.view', 'users.create', 'users.edit', 'users.delete']);
+
         renderWithProvider(
             <UsersPageView
                 title="Gestión de Usuarios"
@@ -111,6 +132,8 @@ describe('UsersPage', () => {
     });
 
     test('hides create button when canCreateUser is false', () => {
+        mockCanFn(['users.view']);
+
         renderWithProvider(
             <UsersPageView
                 title="Gestión de Usuarios"
@@ -128,6 +151,8 @@ describe('UsersPage', () => {
     });
 
     test('renders user rows from context', () => {
+        mockCanFn(['users.view', 'users.create', 'users.edit', 'users.delete']);
+
         const usersState = createMockUsersState({
             users: [mockUser],
             pagination: { current: 1, total: 1, pageSize: 15 },

--- a/src/pages/admin/users/UsersPage.tsx
+++ b/src/pages/admin/users/UsersPage.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { UsersPageView } from './UsersPageView';
 import { UserModal } from '@/features/admin/users/components/UserModal';
 import { useUsers } from '@/features/admin/users/hooks/useUsers';
-import { useAuthStore } from '@/store/useAuthStore.store';
 import { UsersProvider } from '@/features/admin/users/contexts/UsersProvider';
 import type { User } from '@/entities/User';
+import { usePermissions } from '@/hooks/usePermissions';
 
 const routeMetadata = {
     title: 'Gestión de Usuarios',
@@ -17,8 +17,8 @@ const routeMetadata = {
 
 export const UsersPage = () => {
     const usersState = useUsers();
-    const { user } = useAuthStore();
-    const canCreateUser = user?.permissions.includes('users.create') ?? false;
+    const { can } = usePermissions();
+    const canCreateUser = can('users.create');
 
     const [modalOpen, setModalOpen] = useState(false);
     const [selectedUser, setSelectedUser] = useState<User | undefined>(undefined);

--- a/src/pages/admin/users/UsersPageView.tsx
+++ b/src/pages/admin/users/UsersPageView.tsx
@@ -2,6 +2,7 @@ import { Alert, Breadcrumb } from 'antd';
 import { Link } from 'react-router-dom';
 import { PlusOutlined } from '@ant-design/icons';
 import { Button } from '@/components/Button';
+import { CanDo } from '@/components/auth/CanDo';
 import { UserSearchBar } from '@/features/admin/users/components/UserSearchBar';
 import { UsersTable } from '@/features/admin/users/components/UsersTable';
 import type { PageBreadcrumbItem } from '@/router/router.utils';
@@ -48,12 +49,14 @@ export const UsersPageView = ({
                         <p className="usersPageDescription">{description}</p>
                     </div>
                     {canCreateUser && (
-                        <Button
-                            variant="primary"
-                            label="Nuevo Usuario"
-                            icon={<PlusOutlined />}
-                            action={onCreate}
-                        />
+                        <CanDo permission="users.create">
+                            <Button
+                                variant="primary"
+                                label="Nuevo Usuario"
+                                icon={<PlusOutlined />}
+                                action={onCreate}
+                            />
+                        </CanDo>
                     )}
                 </div>
             </div>


### PR DESCRIPTION
- Add usePermissions hook exposing can(permission) function
- Add CanDo wrapper component for conditional rendering based on permissions
- Apply permission checks to all module action buttons (create/edit/delete)
- Update affected test files to mock the new permissions system

Modules updated:
- Stores: create/edit/view permissions
- Users: create/edit/delete permissions
- Plans: create/edit/delete permissions
- Business Types: edit permission (create/edit/delete)
- Features: edit permission (create/edit/delete)
- Roles: edit permission for permissions management